### PR TITLE
css: hanging indent for long sidebar entries

### DIFF
--- a/src/_sass/layout.scss
+++ b/src/_sass/layout.scss
@@ -271,7 +271,7 @@ h4, .docsContent h3 {
 .sidebar-sectionList {
   list-style-type: none;
   margin-bottom: $spacing-unit / 2;
-  margin-left: 0;
+  margin-left: 1.5em;  /* balanced out by text-indent -1.5em below */
 
   font-family: $chrome-font-family;
   font-weight: $chrome-font-weight;
@@ -285,6 +285,7 @@ h4, .docsContent h3 {
 
 .sidebar-sectionList > li {
   margin-bottom: 0;
+  text-indent: -1.5em;
 }
 
 .sidebar-link {


### PR DESCRIPTION
Whelp, this look BETTER at least:

![screen shot 2019-02-21 at 2 03 13 pm](https://user-images.githubusercontent.com/6332648/53194528-8f52e900-35e1-11e9-94be-3ff390b559c1.png)

We should maybe shorten the name of that article regardless tho.