### PR TITLE
fb.add may take string (make this default example in docs) [ch1716]

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -5,20 +5,19 @@ read_file('api/api.py')
 local('make api')
 
 k8s_yaml('serve.yaml')
-repo = local_git_repo('.')
 
 img = fast_build('gcr.io/windmill-public-containers/tilt-site',
                  'base.dockerfile',
                  'bundle exec jekyll serve --config _config.yml,_config-dev.yml')
-img.add(repo.path('src'), '/src/')
+img.add('./src', '/src/')
 img.run('bundle update', trigger=['src/Gemfile', 'src/Gemfile.lock'])
 img.hot_reload()
 
 img = fast_build('gcr.io/windmill-public-containers/docs-site',
                  'docs.dockerfile',
                  'bundle exec jekyll serve --config _config.yml,_config-dev.yml')
-img.add(repo.path('src'), '/src/')
-img.add(repo.path('docs'), '/docs/')
+img.add('./src', '/src/')
+img.add('./docs', '/docs/')
 img.run('bundle update', trigger=['src/Gemfile', 'src/Gemfile.lock', 'docs/Gemfile', 'docs/Gemfile.lock'])
 img.hot_reload()
 

--- a/api/api.py
+++ b/api/api.py
@@ -47,11 +47,11 @@ def docker_build(ref: str, context: str, build_args: Dict[str, str] = {}, docker
 
 class FastBuild:
   """An image that was created with ``fast_build``"""
-  def add(self, src: Union[LocalPath, Repo], dest: str) -> 'FastBuild':
+  def add(self, src: Union[str, LocalPath, Repo], dest: str) -> 'FastBuild':
     """Adds the content from ``src`` into the image at path ``dest``.
 
     Args:
-      src: The content to be added to the image.
+      src: The path to content to be added to the image.
       dest: The path in the image where the content should be added.
 
     """

--- a/docs/fast_build.md
+++ b/docs/fast_build.md
@@ -27,13 +27,11 @@ cd tiltdemo
 The `Tiltfile` at the root of the repo contains this example:
 
 ```python
-repo = local_git_repo('.')
-
 # tiltdemo1
 k8s_yaml('deployments/demoserver1.yaml')
 dm1_img_name = 'gcr.io/windmill-test-containers/tiltdemo/demoserver1'
 (fast_build(dm1_img_name, 'Dockerfile', '/go/bin/demoserver1')
-  .add(repo.path('cmd/demoserver1'),
+  .add('./cmd/demoserver1',
       '/go/src/github.com/windmilleng/tiltdemo/cmd/demoserver1')
   .run('go install github.com/windmilleng/tiltdemo/cmd/demoserver1'))
 ```
@@ -45,7 +43,7 @@ in on that part of the function.
 
 ```python
 (fast_build(dm1_img_name, 'Dockerfile', '/go/bin/demoserver1')
-  .add(repo.path('cmd/demoserver1'),
+  .add('./cmd/demoserver1',
       '/go/src/github.com/windmilleng/tiltdemo/cmd/demoserver1')
   .run('go install github.com/windmilleng/tiltdemo/cmd/demoserver1'))
 ```
@@ -71,14 +69,14 @@ Fast build Dockerfiles cannot contain any ADD or COPY lines.
 It's only for setting up the environment, not for adding your code.
 So this Dockerfile might look different than most.
 
-* `add(repo.path('cmd/demoserver1'), '/go/src/github.com/windmilleng/tiltdemo/cmd/demoserver1')`
+* `add('./cmd/demoserver1', '/go/src/github.com/windmilleng/tiltdemo/cmd/demoserver1')`
 
 The `add` method copies a directory from outside your container to inside of your container.
 
-In this case, we copy the directory `cmd/demoserver` inside of our Git repo into
+In this case, we copy the directory `./cmd/demoserver` (relative to the Tiltfile) into
 the container filesystem.
 
-While Tilt is running, it watches all files in cmd/demoserver. If they change, it copies the file
+While Tilt is running, it watches all files in `./cmd/demoserver`. If they change, it copies the file
 into the container.
 
 * `run('go install github.com/windmilleng/tiltdemo/cmd/demoserver1')`

--- a/docs/nodejs_microservice_hotreloading.md
+++ b/docs/nodejs_microservice_hotreloading.md
@@ -25,7 +25,7 @@ Now we need to tell Tilt about the Docker image that is used in the provided Kub
 
 ```python
 img = fast_build('tilt-frontend-demo', 'Dockerfile', 'npm start')
-img.add(repo.path('.'), '/src')
+img.add('.', '/src')
 img.run('npm install')
 ```
 

--- a/docs/tiltfile_concepts.md
+++ b/docs/tiltfile_concepts.md
@@ -12,7 +12,7 @@ Functions like `k8s_yaml` and `docker_build` register information. At the end of
 
 Because your Tiltfile is a program, you can configure it with familiar constructs like loops, functions, arrays, etc. This makes Tilt more extensible than a configuration that requires hard-coding all possible options up-front.
 
-Any relative paths in your Tiltfile are evaluated relative to the location of the Tiltfile. (Absolute paths are also fine!)
+Any relative paths in your Tiltfile are evaluated relative to the location of the Tiltfile.
 
 ## Deploy
 The first function in a `Tiltfile` is generally a call to `k8s_yaml`. You can call `k8s_yaml` in a variety of ways, depending on how your project organizes or generates YAML. Let's look at some alternatives:

--- a/docs/tiltfile_concepts.md
+++ b/docs/tiltfile_concepts.md
@@ -12,6 +12,8 @@ Functions like `k8s_yaml` and `docker_build` register information. At the end of
 
 Because your Tiltfile is a program, you can configure it with familiar constructs like loops, functions, arrays, etc. This makes Tilt more extensible than a configuration that requires hard-coding all possible options up-front.
 
+Any relative paths in your Tiltfile are evaluated relative to the location of the Tiltfile. (Absolute paths are also fine!)
+
 ## Deploy
 The first function in a `Tiltfile` is generally a call to `k8s_yaml`. You can call `k8s_yaml` in a variety of ways, depending on how your project organizes or generates YAML. Let's look at some alternatives:
 

--- a/src/_includes/api.html
+++ b/src/_includes/api.html
@@ -17,7 +17,7 @@
 <col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>src</strong> (<code class="xref py py-data docutils literal notranslate"><span class="pre">Union</span></code>[<a class="reference internal" href="#api.LocalPath" title="api.LocalPath"><code class="xref py py-class docutils literal notranslate"><span class="pre">LocalPath</span></code></a>, <a class="reference internal" href="#api.Repo" title="api.Repo"><code class="xref py py-class docutils literal notranslate"><span class="pre">Repo</span></code></a>]) &#x2013; The content to be added to the image.</li>
+<li><strong>src</strong> (<code class="xref py py-data docutils literal notranslate"><span class="pre">Union</span></code>[<code class="xref py py-class docutils literal notranslate"><span class="pre">str</span></code>, <a class="reference internal" href="#api.LocalPath" title="api.LocalPath"><code class="xref py py-class docutils literal notranslate"><span class="pre">LocalPath</span></code></a>, <a class="reference internal" href="#api.Repo" title="api.Repo"><code class="xref py py-class docutils literal notranslate"><span class="pre">Repo</span></code></a>]) &#x2013; The path to content to be added to the image.</li>
 <li><strong>dest</strong> (<code class="xref py py-class docutils literal notranslate"><span class="pre">str</span></code>) &#x2013; The path in the image where the content should be added.</li>
 </ul>
 </td>
@@ -293,7 +293,7 @@ applies to your k8s cluster independently.</p>
 </dd></dl><dl class="function">
 <dt id="api.listdir">
 <code class="descclassname">api.</code><code class="descname">listdir</code><span class="sig-paren">(</span><em>directory</em>, <em>recursive=False</em><span class="sig-paren">)</span><a class="headerlink" href="#api.listdir" title="Permalink to this definition">&#xB6;</a></dt>
-<dd><p>Returns all the files at the top level of the provided directory. If <code class="docutils literal notranslate"><span class="pre">recursive</span></code> is set to True, then all files are returned that are inside of the provided directory, recursively.</p>
+<dd><p>Returns all the files at the top level of the provided directory. If <code class="docutils literal notranslate"><span class="pre">recursive</span></code> is set to True, returns all files that are inside of the provided directory, recursively.</p>
 <table class="docutils field-list" frame="void" rules="none">
 <col class="field-name">
 <col class="field-body">


### PR DESCRIPTION
Hello @jazzdan, @landism,

Please review the following commits I made in branch maiamcc/add-takes-string:

c89db3f0f511e45f69417178339cb9f9c3a0f011 (2019-02-28 15:24:57 -0500)
fb.add may take string (make this default example in docs)

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics