### PR TITLE
remove localpath/gitrepo from api reference to clarify type signatures

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -1,8 +1,5 @@
 from typing import Dict, Union, List, Callable
 
-class LocalPath:
-  """A path on disk"""
-
 class Blob:
   """The result of executing a command on your local system.
 
@@ -10,26 +7,7 @@ class Blob:
 
    To wrap a string as a blob, call ``blob(my_str)``"""
 
-class Repo:
-  """Represents a version control repository"""
-  def path(self, path: str) -> LocalPath:
-    """Returns the absolute path to the file specified at ``path`` in the repo.
-    path must be a relative path.
-
-    Respects ``.gitignore``.
-
-    Args:
-      path: relative path in repository
-    Returns:
-      A LocalPath resource, representing a local path on disk.
-    """
-    pass
-
-def local_git_repo(path: str) -> Repo:
-  """Creates a ``repo`` from the git repo at ``path``."""
-  pass
-
-def docker_build(ref: str, context: str, build_args: Dict[str, str] = {}, dockerfile: Union[str, LocalPath] = "Dockerfile", dockerfile_contents: Union[str, Blob] = "") -> None:
+def docker_build(ref: str, context: str, build_args: Dict[str, str] = {}, dockerfile: str = "Dockerfile", dockerfile_contents: Union[str, Blob] = "") -> None:
   """Builds a docker image.
 
   Note that you can't set both the `dockerfile` and `dockerfile_contents` arguments (will throw an error).
@@ -40,18 +18,18 @@ def docker_build(ref: str, context: str, build_args: Dict[str, str] = {}, docker
     ref: name for this image (e.g. 'myproj/backend' or 'myregistry/myproj/backend'). If this image will be used in a k8s resource(s), this ref must match the ``spec.container.image`` param for that resource(s).
     context: path to use as the Docker build context.
     build_args: build-time variables that are accessed like regular environment variables in the ``RUN`` instruction of the Dockerfile. See `the Docker Build Arg documentation <https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg>`_
-    dockerfile: path to the Dockerfile to build (may be absolute, or relative to cwd)
+    dockerfile: path to the Dockerfile to build
     dockerfile_contents: raw contents of the Dockerfile to use for this build
   """
   pass
 
 class FastBuild:
   """An image that was created with ``fast_build``"""
-  def add(self, src: Union[str, LocalPath, Repo], dest: str) -> 'FastBuild':
+  def add(self, src: str, dest: str) -> 'FastBuild':
     """Adds the content from ``src`` into the image at path ``dest``.
 
     Args:
-      src: The path to content to be added to the image.
+      src: The path to content to be added to the image (absolute, or relative to the location of the Tiltfile).
       dest: The path in the image where the content should be added.
 
     """
@@ -80,7 +58,7 @@ def fast_build(img_name: str, dockerfile_path: str, entrypoint: str = "") -> Fas
   """
   pass
 
-def k8s_yaml(yaml: Union[str, List[str], LocalPath, Blob]) -> None:
+def k8s_yaml(yaml: Union[str, List[str], Blob]) -> None:
   """Call this with a path to a file that contains YAML, or with a ``Blob`` of YAML.
 
   We will infer what (if any) of the k8s resources defined in your YAML
@@ -97,10 +75,6 @@ def k8s_yaml(yaml: Union[str, List[str], LocalPath, Blob]) -> None:
 
     # list of paths
     k8s_yaml(['foo.yaml', 'bar.yaml'])
-
-    # LocalPath
-    repo = local_git_repo('./my_proj')
-    k8s_yaml(repo.path('deploy/foo.yaml'))
 
     # Blob, i.e. `local` output (in this case, script output)
     templated_yaml = local('./template_yaml.sh')
@@ -137,7 +111,7 @@ def k8s_resource(name: str, yaml: Union[str, Blob] = "", image: Union[str, FastB
   """
   pass
 
-def filter_yaml(yaml: Union[str, List[str], LocalPath, Blob], labels: dict=None, name: str=None, namespace: str=None, kind: str=None):
+def filter_yaml(yaml: Union[str, List[str], Blob], labels: dict=None, name: str=None, namespace: str=None, kind: str=None):
   """Call this with a path to a file that contains YAML, or with a ``Blob`` of YAML.
   (E.g. it can be called on the output of ``kustomize`` or ``helm``.)
 
@@ -177,20 +151,26 @@ def local(cmd: str) -> Blob:
   """Runs cmd, waits for it to finish, and returns its stdout as a ``Blob``"""
   pass
 
-def read_file(file_path: Union[str, LocalPath]) -> Blob:
+def read_file(file_path: str) -> Blob:
   """Reads file and returns its contents.
 
   Args:
-    file_path: Path to the file locally"""
+    file_path: Path to the file locally (absolute, or relative to the location of the Tiltfile)."""
   pass
 
 
 def kustomize(pathToDir: str) -> Blob:
-  """Run `kustomize <https://github.com/kubernetes-sigs/kustomize>`_ on a given directory and return the resulting YAML as a Blob"""
+  """Run `kustomize <https://github.com/kubernetes-sigs/kustomize>`_ on a given directory and return the resulting YAML as a Blob
+
+  Args:
+    pathToDir: Path to the directory locally (absolute, or relative to the location of the Tiltfile)."""
   pass
 
-def helm(pathToChartDir: Union[str, LocalPath]) -> Blob:
-  """Run `helm template <https://docs.helm.sh/helm/#helm-template>`_ on a given directory that contains a chart and return the fully rendered YAML as a Blob"""
+def helm(pathToChartDir: str) -> Blob:
+  """Run `helm template <https://docs.helm.sh/helm/#helm-template>`_ on a given directory that contains a chart and return the fully rendered YAML as a Blob
+
+  Args:
+    pathToChartDir: Path to the directory locally (absolute, or relative to the location of the Tiltfile)."""
   pass
 
 def fail(msg: str) -> None:

--- a/src/_includes/api.html
+++ b/src/_includes/api.html
@@ -17,7 +17,7 @@
 <col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>src</strong> (<code class="xref py py-data docutils literal notranslate"><span class="pre">Union</span></code>[<code class="xref py py-class docutils literal notranslate"><span class="pre">str</span></code>, <a class="reference internal" href="#api.LocalPath" title="api.LocalPath"><code class="xref py py-class docutils literal notranslate"><span class="pre">LocalPath</span></code></a>, <a class="reference internal" href="#api.Repo" title="api.Repo"><code class="xref py py-class docutils literal notranslate"><span class="pre">Repo</span></code></a>]) &#x2013; The path to content to be added to the image.</li>
+<li><strong>src</strong> (<code class="xref py py-class docutils literal notranslate"><span class="pre">str</span></code>) &#x2013; The path to content to be added to the image (absolute, or relative to the location of the Tiltfile).</li>
 <li><strong>dest</strong> (<code class="xref py py-class docutils literal notranslate"><span class="pre">str</span></code>) &#x2013; The path in the image where the content should be added.</li>
 </ul>
 </td>
@@ -65,34 +65,6 @@
 </table>
 </dd></dl>
 
-</dd></dl><dl class="class">
-<dt id="api.LocalPath">
-<em class="property">class </em><code class="descclassname">api.</code><code class="descname">LocalPath</code><a class="headerlink" href="#api.LocalPath" title="Permalink to this definition">&#xB6;</a></dt>
-<dd><p>A path on disk</p>
-</dd></dl><dl class="class">
-<dt id="api.Repo">
-<em class="property">class </em><code class="descclassname">api.</code><code class="descname">Repo</code><a class="headerlink" href="#api.Repo" title="Permalink to this definition">&#xB6;</a></dt>
-<dd><p>Represents a version control repository</p>
-<dl class="method">
-<dt id="api.Repo.path">
-<code class="descname">path</code><span class="sig-paren">(</span><em>path</em><span class="sig-paren">)</span><a class="headerlink" href="#api.Repo.path" title="Permalink to this definition">&#xB6;</a></dt>
-<dd><p>Returns the absolute path to the file specified at <code class="docutils literal notranslate"><span class="pre">path</span></code> in the repo.
-path must be a relative path.</p>
-<p>Respects <code class="docutils literal notranslate"><span class="pre">.gitignore</span></code>.</p>
-<table class="docutils field-list" frame="void" rules="none">
-<col class="field-name">
-<col class="field-body">
-<tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>path</strong> (<code class="xref py py-class docutils literal notranslate"><span class="pre">str</span></code>) &#x2013; relative path in repository</td>
-</tr>
-<tr class="field-even field"><th class="field-name">Return type:</th><td class="field-body"><a class="reference internal" href="#api.LocalPath" title="api.LocalPath"><code class="xref py py-class docutils literal notranslate"><span class="pre">LocalPath</span></code></a></td>
-</tr>
-<tr class="field-odd field"><th class="field-name">Returns:</th><td class="field-body">A LocalPath resource, representing a local path on disk.</td>
-</tr>
-</tbody>
-</table>
-</dd></dl>
-
 </dd></dl><dl class="function">
 <dt id="api.blob">
 <code class="descclassname">api.</code><code class="descname">blob</code><span class="sig-paren">(</span><em>contents</em><span class="sig-paren">)</span><a class="headerlink" href="#api.blob" title="Permalink to this definition">&#xB6;</a></dt>
@@ -119,7 +91,7 @@ path must be a relative path.</p>
 <li><strong>ref</strong> (<code class="xref py py-class docutils literal notranslate"><span class="pre">str</span></code>) &#x2013; name for this image (e.g. &#x2018;myproj/backend&#x2019; or &#x2018;myregistry/myproj/backend&#x2019;). If this image will be used in a k8s resource(s), this ref must match the <code class="docutils literal notranslate"><span class="pre">spec.container.image</span></code> param for that resource(s).</li>
 <li><strong>context</strong> (<code class="xref py py-class docutils literal notranslate"><span class="pre">str</span></code>) &#x2013; path to use as the Docker build context.</li>
 <li><strong>build_args</strong> (<code class="xref py py-class docutils literal notranslate"><span class="pre">Dict</span></code>[<code class="xref py py-class docutils literal notranslate"><span class="pre">str</span></code>, <code class="xref py py-class docutils literal notranslate"><span class="pre">str</span></code>]) &#x2013; build-time variables that are accessed like regular environment variables in the <code class="docutils literal notranslate"><span class="pre">RUN</span></code> instruction of the Dockerfile. See <a class="reference external" href="https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg">the Docker Build Arg documentation</a></li>
-<li><strong>dockerfile</strong> (<code class="xref py py-data docutils literal notranslate"><span class="pre">Union</span></code>[<code class="xref py py-class docutils literal notranslate"><span class="pre">str</span></code>, <a class="reference internal" href="#api.LocalPath" title="api.LocalPath"><code class="xref py py-class docutils literal notranslate"><span class="pre">LocalPath</span></code></a>]) &#x2013; path to the Dockerfile to build (may be absolute, or relative to cwd)</li>
+<li><strong>dockerfile</strong> (<code class="xref py py-class docutils literal notranslate"><span class="pre">str</span></code>) &#x2013; path to the Dockerfile to build</li>
 <li><strong>dockerfile_contents</strong> (<code class="xref py py-data docutils literal notranslate"><span class="pre">Union</span></code>[<code class="xref py py-class docutils literal notranslate"><span class="pre">str</span></code>, <a class="reference internal" href="#api.Blob" title="api.Blob"><code class="xref py py-class docutils literal notranslate"><span class="pre">Blob</span></code></a>]) &#x2013; raw contents of the Dockerfile to use for this build</li>
 </ul>
 </td>
@@ -176,7 +148,7 @@ returns the non-matching YAML as the second return value.</p>
 <col class="field-body">
 <tbody valign="top">
 <tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>yaml</strong> (<code class="xref py py-data docutils literal notranslate"><span class="pre">Union</span></code>[<code class="xref py py-class docutils literal notranslate"><span class="pre">str</span></code>, <code class="xref py py-class docutils literal notranslate"><span class="pre">List</span></code>[<code class="xref py py-class docutils literal notranslate"><span class="pre">str</span></code>], <a class="reference internal" href="#api.LocalPath" title="api.LocalPath"><code class="xref py py-class docutils literal notranslate"><span class="pre">LocalPath</span></code></a>, <a class="reference internal" href="#api.Blob" title="api.Blob"><code class="xref py py-class docutils literal notranslate"><span class="pre">Blob</span></code></a>]) &#x2013; Path(s) to YAML, or YAML as a <code class="docutils literal notranslate"><span class="pre">Blob</span></code>.</li>
+<li><strong>yaml</strong> (<code class="xref py py-data docutils literal notranslate"><span class="pre">Union</span></code>[<code class="xref py py-class docutils literal notranslate"><span class="pre">str</span></code>, <code class="xref py py-class docutils literal notranslate"><span class="pre">List</span></code>[<code class="xref py py-class docutils literal notranslate"><span class="pre">str</span></code>], <a class="reference internal" href="#api.Blob" title="api.Blob"><code class="xref py py-class docutils literal notranslate"><span class="pre">Blob</span></code></a>]) &#x2013; Path(s) to YAML, or YAML as a <code class="docutils literal notranslate"><span class="pre">Blob</span></code>.</li>
 <li><strong>labels</strong> (<code class="xref py py-data docutils literal notranslate"><span class="pre">Optional</span></code>[<code class="xref py py-class docutils literal notranslate"><span class="pre">dict</span></code>]) &#x2013; (optional) return only entities matching these labels. (Matching entities
 must satisfy all of the specified label constraints, though they may have additional
 labels as well: see the <a class="reference external" href="https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/">Kubernetes docs</a>
@@ -206,7 +178,9 @@ Case-insensitive. NOTE: doesn&#x2019;t support abbreviations like &#x201C;svc&#x
 <col class="field-name">
 <col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body"><a class="reference internal" href="#api.Blob" title="api.Blob"><code class="xref py py-class docutils literal notranslate"><span class="pre">Blob</span></code></a></td>
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>pathToChartDir</strong> (<code class="xref py py-class docutils literal notranslate"><span class="pre">str</span></code>) &#x2013; Path to the directory locally (absolute, or relative to the location of the Tiltfile).</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Return type:</th><td class="field-body"><a class="reference internal" href="#api.Blob" title="api.Blob"><code class="xref py py-class docutils literal notranslate"><span class="pre">Blob</span></code></a></td>
 </tr>
 </tbody>
 </table>
@@ -260,10 +234,6 @@ applies to your k8s cluster independently.</p>
 <span class="c1"># list of paths</span>
 <span class="n">k8s_yaml</span><span class="p">([</span><span class="s1">&apos;foo.yaml&apos;</span><span class="p">,</span> <span class="s1">&apos;bar.yaml&apos;</span><span class="p">])</span>
 
-<span class="c1"># LocalPath</span>
-<span class="n">repo</span> <span class="o">=</span> <span class="n">local_git_repo</span><span class="p">(</span><span class="s1">&apos;./my_proj&apos;</span><span class="p">)</span>
-<span class="n">k8s_yaml</span><span class="p">(</span><span class="n">repo</span><span class="o">.</span><span class="n">path</span><span class="p">(</span><span class="s1">&apos;deploy/foo.yaml&apos;</span><span class="p">))</span>
-
 <span class="c1"># Blob, i.e. `local` output (in this case, script output)</span>
 <span class="n">templated_yaml</span> <span class="o">=</span> <span class="n">local</span><span class="p">(</span><span class="s1">&apos;./template_yaml.sh&apos;</span><span class="p">)</span>
 <span class="n">k8s_yaml</span><span class="p">(</span><span class="n">templated_yaml</span><span class="p">)</span>
@@ -273,7 +243,7 @@ applies to your k8s cluster independently.</p>
 <col class="field-name">
 <col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>yaml</strong> (<code class="xref py py-data docutils literal notranslate"><span class="pre">Union</span></code>[<code class="xref py py-class docutils literal notranslate"><span class="pre">str</span></code>, <code class="xref py py-class docutils literal notranslate"><span class="pre">List</span></code>[<code class="xref py py-class docutils literal notranslate"><span class="pre">str</span></code>], <a class="reference internal" href="#api.LocalPath" title="api.LocalPath"><code class="xref py py-class docutils literal notranslate"><span class="pre">LocalPath</span></code></a>, <a class="reference internal" href="#api.Blob" title="api.Blob"><code class="xref py py-class docutils literal notranslate"><span class="pre">Blob</span></code></a>]) &#x2013; Path(s) to YAML, or YAML as a <code class="docutils literal notranslate"><span class="pre">Blob</span></code>.</td>
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>yaml</strong> (<code class="xref py py-data docutils literal notranslate"><span class="pre">Union</span></code>[<code class="xref py py-class docutils literal notranslate"><span class="pre">str</span></code>, <code class="xref py py-class docutils literal notranslate"><span class="pre">List</span></code>[<code class="xref py py-class docutils literal notranslate"><span class="pre">str</span></code>], <a class="reference internal" href="#api.Blob" title="api.Blob"><code class="xref py py-class docutils literal notranslate"><span class="pre">Blob</span></code></a>]) &#x2013; Path(s) to YAML, or YAML as a <code class="docutils literal notranslate"><span class="pre">Blob</span></code>.</td>
 </tr>
 <tr class="field-even field"><th class="field-name">Return type:</th><td class="field-body"><code class="docutils literal notranslate"><span class="pre">None</span></code></td>
 </tr>
@@ -287,7 +257,9 @@ applies to your k8s cluster independently.</p>
 <col class="field-name">
 <col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body"><a class="reference internal" href="#api.Blob" title="api.Blob"><code class="xref py py-class docutils literal notranslate"><span class="pre">Blob</span></code></a></td>
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>pathToDir</strong> (<code class="xref py py-class docutils literal notranslate"><span class="pre">str</span></code>) &#x2013; Path to the directory locally (absolute, or relative to the location of the Tiltfile).</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Return type:</th><td class="field-body"><a class="reference internal" href="#api.Blob" title="api.Blob"><code class="xref py py-class docutils literal notranslate"><span class="pre">Blob</span></code></a></td>
 </tr>
 </tbody>
 </table>
@@ -316,18 +288,6 @@ applies to your k8s cluster independently.</p>
 </tbody>
 </table>
 </dd></dl><dl class="function">
-<dt id="api.local_git_repo">
-<code class="descclassname">api.</code><code class="descname">local_git_repo</code><span class="sig-paren">(</span><em>path</em><span class="sig-paren">)</span><a class="headerlink" href="#api.local_git_repo" title="Permalink to this definition">&#xB6;</a></dt>
-<dd><p>Creates a <code class="docutils literal notranslate"><span class="pre">repo</span></code> from the git repo at <code class="docutils literal notranslate"><span class="pre">path</span></code>.</p>
-<table class="docutils field-list" frame="void" rules="none">
-<col class="field-name">
-<col class="field-body">
-<tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body"><a class="reference internal" href="#api.Repo" title="api.Repo"><code class="xref py py-class docutils literal notranslate"><span class="pre">Repo</span></code></a></td>
-</tr>
-</tbody>
-</table>
-</dd></dl><dl class="function">
 <dt id="api.read_file">
 <code class="descclassname">api.</code><code class="descname">read_file</code><span class="sig-paren">(</span><em>file_path</em><span class="sig-paren">)</span><a class="headerlink" href="#api.read_file" title="Permalink to this definition">&#xB6;</a></dt>
 <dd><p>Reads file and returns its contents.</p>
@@ -335,7 +295,7 @@ applies to your k8s cluster independently.</p>
 <col class="field-name">
 <col class="field-body">
 <tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>file_path</strong> (<code class="xref py py-data docutils literal notranslate"><span class="pre">Union</span></code>[<code class="xref py py-class docutils literal notranslate"><span class="pre">str</span></code>, <a class="reference internal" href="#api.LocalPath" title="api.LocalPath"><code class="xref py py-class docutils literal notranslate"><span class="pre">LocalPath</span></code></a>]) &#x2013; Path to the file locally</td>
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><strong>file_path</strong> (<code class="xref py py-class docutils literal notranslate"><span class="pre">str</span></code>) &#x2013; Path to the file locally (absolute, or relative to the location of the Tiltfile).</td>
 </tr>
 <tr class="field-even field"><th class="field-name">Return type:</th><td class="field-body"><a class="reference internal" href="#api.Blob" title="api.Blob"><code class="xref py py-class docutils literal notranslate"><span class="pre">Blob</span></code></a></td>
 </tr>


### PR DESCRIPTION
Hello @jazzdan, @landism,

Please review the following commits I made in branch maiamcc/rm-localpath-from-docs:

7c33d85bc34caff18d53741e123217cc06c3f4b4 (2019-02-28 16:55:26 -0500)
remove localpath/gitrepo from api reference to clarify type signatures

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics