### PR TITLE
docs: update for workload assembly

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -174,11 +174,11 @@ def filter_yaml(yaml: Union[str, List[str], Blob], labels: dict=None, name: str=
 
     # extract all YAMLs matching labels "app=foobar"
     foobar_yaml, rest = filter_yaml('all.yaml', labels={'app': 'foobar'}
-    k8s_resource('foobar', yaml=foobar_yaml)
+    k8s_yaml(foobar_yaml)
 
     # extract YAMLs of kind "deployment" with metadata.name "baz"
     baz_yaml, rest = filter_yaml(rest, name='baz', kind='deployment')
-    k8s_resource('baz', yaml=baz_yaml)
+    k8s_yaml(baz_yaml)
 
   Args:
     yaml: Path(s) to YAML, or YAML as a ``Blob``.

--- a/api/api.py
+++ b/api/api.py
@@ -87,9 +87,59 @@ def k8s_yaml(yaml: Union[str, List[str], Blob]) -> None:
   """
   pass
 
-def k8s_resource(name: str, yaml: Union[str, Blob] = "", image: Union[str, FastBuild] = "",
+def k8s_resource(workload: str, new_name: str = "",
+                 port_forwards: Union[str, int, List[int]] = [],
+                 extra_pod_selectors: Union[Dict[str, str], List[Dict[str, str]]] = []) -> None:
+  """Configures a kubernetes resources
+
+  If :meth:`k8s_resource_assembly_version` has been called with `1`, see
+  :meth:`k8s_resource_v1_DEPRECATED` instead.
+
+  Args:
+    workload: which workload's resource to configure. This is a colon-separated
+      string consisting of one or more of (name, kind, namespace, group), e.g.,
+      "redis", "redis:deployment", or "redis:deployment:default".
+      `k8s_resource` searches all loaded k8s workload objects for an object matching
+      all given fields. If there's exactly one, `k8s_resource` configures options for
+      that workload. If there's not exactly one, `k8s_resource` raises an error.
+      (e.g., "redis" suffices if there's only one object named "redis", but if
+      there's both a deployment and a cronjob named "redis", you'd need to specify
+      "redis:deployment").
+    new_name: if non-empty, will be used as the new name for this resource
+    port_forwards: Local ports to connect to the pod. If no
+      target port is specified, will use the first container port.
+      Example values: 9000 (connect localhost:9000 to the default container port),
+      '9000:8000' (connect localhost:9000 to the container port 8000),
+      ['9000:8000', '9001:8001'] (connect localhost:9000 and :9001 to the
+      container ports 8000 and 8001, respectively).
+    extra_pod_selectors: In addition to relying on Tilt's heuristics to automatically
+      find K8S resources associated with this resource, a user may specify extra
+      labelsets to force entities to be associated with this resource. An entity
+      will be associated with this resource if it has all of the labels in at
+      least one of the entries specified (but still also if it meets any of
+      Tilt's usual mechanisms).
+  """
+
+  pass
+
+def k8s_resource_assembly_version(version: int) -> None:
+  """
+  Specifies which version of k8s resource assembly loading to use.
+
+  This function is deprecated and will be removed.
+  See `Resource Assembly Migration </resource_assembly_migration.html>`_ for information.
+
+  Changes the behavior of :meth:`k8s_resource`.
+  """
+
+def k8s_resource_v1_DEPRECATED(name: str, yaml: Union[str, Blob] = "", image: Union[str, FastBuild] = "",
     port_forwards: Union[str, int, List[int]] = [], extra_pod_selectors: Union[Dict[str, str], List[Dict[str, str]]] = []) -> None:
-  """Creates a kubernetes resource that tilt can deploy using the specified image.
+  """NOTE: This is actually named :meth:`k8s_resource`. This documents
+  the behavior of this method after a call to :meth:`k8s_resource_assembly_version` with value `1`.
+  This behavior is deprecated and will be removed.
+  See `Resource Assembly Migration </resource_assembly_migration.html>`_ for information.
+
+  Creates a kubernetes resource that tilt can deploy using the specified image.
 
   Args:
     name: What call this resource in the UI. If ``image`` is not specified ``name`` will be used as the image to group by.

--- a/docs/resource_assembly_migration.md
+++ b/docs/resource_assembly_migration.md
@@ -1,0 +1,39 @@
+---
+title: Tiltfile Resource Assembly Migration
+layout: docs
+---
+
+Tilt is changing how it combines k8s objects and images into Tilt resources.
+
+If you don't want to deal with this right now, you can get back the old
+behavior for now by adding `k8s_resource_assembly_version(1)` to the top of
+your Tiltfile. We plan to remove that option on 2019-05-01. [Please let us know](http://localhost:4001/faq.html#q-how-do-i-get-help-with-tilt) if you have questions or concerns about any of this!
+
+The old behavior was roughly to make one Tilt resource per image, and associate
+a resource with all k8s objects that use that image. This led to confusing behavior
+when multiple Deployments used the same image, and was just generally unintuitive.
+
+The new behavior is to simply make one Tilt resource per k8s object that has a
+container. It's described [here](tiltfile_concepts.html#resources).
+
+This might affect you in a few ways:
+* Tilt resources are now named after their k8s objects rather than their images.
+* If you had multiple k8s objects using the same image, they'll now each be
+a separate Tilt resource, instead of all getting combined into one.
+* `k8s_resource` arguments are changing.
+
+The old `k8s_resource` behavior was kind of weird: sometimes you could just use
+the image name, and sometimes you'd pass the yaml, and sometimes you'd pass the
+image. Sometimes it was used for creating a resource, and sometimes it was used
+for configuring an existing resource.
+
+We've eliminated `k8s_resource`'s 'yaml' and 'image' parameters. It's now a
+function for configuring a workload's resource. You can find documentation
+for its new behavior [here](api.html#api.k8s_resource).
+
+Migrating to the new behavior should mostly be a matter of removing any 'yaml'
+or 'image' args to `k8s_resource` calls, and making sure those 'yaml' args
+are passed to `k8s_yaml` somewhere else in your Tiltfile.
+
+Please don't hesitate to [reach out](http://localhost:4001/faq.html#q-how-do-i-get-help-with-tilt)
+if you run into any problems or confusion!

--- a/docs/resource_assembly_migration.md
+++ b/docs/resource_assembly_migration.md
@@ -3,18 +3,14 @@ title: Tiltfile Resource Assembly Migration
 layout: docs
 ---
 
-Tilt is changing how it combines k8s objects and images into Tilt resources.
+Tilt is changing how it combines k8s objects and images into Tilt [resources](tiltfile_concepts#resources).
 
 If you don't want to deal with this right now, you can get back the old
 behavior for now by adding `k8s_resource_assembly_version(1)` to the top of
-your Tiltfile. We plan to remove that option on 2019-05-01. [Please let us know](http://localhost:4001/faq.html#q-how-do-i-get-help-with-tilt) if you have questions or concerns about any of this!
+your Tiltfile. We plan to remove that option on 2019-05-01. [Please let us know](faq.html#q-how-do-i-get-help-with-tilt) if you have questions or concerns about any of this!
 
-The old behavior was roughly to make one Tilt resource per image, and associate
-a resource with all k8s objects that use that image. This led to confusing behavior
-when multiple Deployments used the same image, and was just generally unintuitive.
-
-The new behavior is to simply make one Tilt resource per k8s object that has a
-container. It's described [here](tiltfile_concepts.html#resources).
+The new behavior is to simply make one Tilt resource per k8s object that has at least one
+container. ([Read more about the new behavior](tiltfile_concepts.html#resources))
 
 This might affect you in a few ways:
 * Tilt resources are now named after their k8s objects rather than their images.
@@ -28,12 +24,11 @@ image. Sometimes it was used for creating a resource, and sometimes it was used
 for configuring an existing resource.
 
 We've eliminated `k8s_resource`'s 'yaml' and 'image' parameters. It's now a
-function for configuring a workload's resource. You can find documentation
-for its new behavior [here](api.html#api.k8s_resource).
+function for configuring a workload's resource. ([See the API docs for the new `k8s_resource`](api.html#api.k8s_resource))
 
 Migrating to the new behavior should mostly be a matter of removing any 'yaml'
 or 'image' args to `k8s_resource` calls, and making sure those 'yaml' args
 are passed to `k8s_yaml` somewhere else in your Tiltfile.
 
-Please don't hesitate to [reach out](http://localhost:4001/faq.html#q-how-do-i-get-help-with-tilt)
+Please don't hesitate to [reach out](faq.html#q-how-do-i-get-help-with-tilt)
 if you run into any problems or confusion!

--- a/docs/resource_assembly_migration.md
+++ b/docs/resource_assembly_migration.md
@@ -3,20 +3,13 @@ title: Tiltfile Resource Assembly Migration
 layout: docs
 ---
 
-Tilt is changing how it combines k8s objects and images into Tilt [resources](tiltfile_concepts#resources).
+Tilt is changing how it combines k8s objects and images into Tilt [resources](tiltfile_concepts#resources). The new behavior is to simply make one Tilt resource per k8s object that has at least one
+container.
 
-If you don't want to deal with this right now, you can get back the old
-behavior for now by adding `k8s_resource_assembly_version(1)` to the top of
-your Tiltfile. We plan to remove that option on 2019-05-01. [Please let us know](faq.html#q-how-do-i-get-help-with-tilt) if you have questions or concerns about any of this!
-
-The new behavior is to simply make one Tilt resource per k8s object that has at least one
-container. ([Read more about the new behavior](tiltfile_concepts.html#resources))
-
-This might affect you in a few ways:
-* Tilt resources are now named after their k8s objects rather than their images.
-* If you had multiple k8s objects using the same image, they'll now each be
-a separate Tilt resource, instead of all getting combined into one.
-* `k8s_resource` arguments are changing.
+The TL;DR is:
+* Your tilt resources' names might change.
+* You might need to change how you're calling `k8s_resource`.
+* You might need to temporarily add a call to `k8s_resource_assembly_version` to the top of your Tiltfile.
 
 The old `k8s_resource` behavior was kind of weird: sometimes you could just use
 the image name, and sometimes you'd pass the yaml, and sometimes you'd pass the
@@ -26,9 +19,11 @@ for configuring an existing resource.
 We've eliminated `k8s_resource`'s 'yaml' and 'image' parameters. It's now a
 function for configuring a workload's resource. ([See the API docs for the new `k8s_resource`](api.html#api.k8s_resource))
 
-Migrating to the new behavior should mostly be a matter of removing any 'yaml'
-or 'image' args to `k8s_resource` calls, and making sure those 'yaml' args
-are passed to `k8s_yaml` somewhere else in your Tiltfile.
+Migrating to the new behavior should mostly be a matter of:
+1. Adding a call to `k8s_resource_assembly_version(2)` to the top of your Tiltfile (if running Tilt version < 0.8.0)
+2. removing any 'yaml' or 'image' args to `k8s_resource` calls
+3. and making any removed 'yaml' args from (2) are passed to `k8s_yaml` somewhere else in your Tiltfile.
+4. Letting any teammates know that they need to upgrade Tilt.
 
 Please don't hesitate to [reach out](faq.html#q-how-do-i-get-help-with-tilt)
 if you run into any problems or confusion!

--- a/docs/tiltfile_concepts.md
+++ b/docs/tiltfile_concepts.md
@@ -130,18 +130,15 @@ You can combine multiple optional arguments.
 ## Resources
 Tilt's UI makes it easier to find errors by grouping related status and output. E.g., when you edit a file, you want to know what error it caused, whether it's an error at build-time, deploy-time, or run-time. Tilt calls these groupings "Resources". Each Resource has a line in the UI that can be expanded and investigated.
 
-Tilt generates these groups after executing your `Tiltfile`. We're actively working on how to group in ways that make the most intuitive sense, so the specific algorithm is in-flux. We'll expand this paragraph when it's more settled.
+Tilt generates these groups after executing your `Tiltfile`. It does this by scanning all loaded yaml for any k8s objects that it considers a "workload" (i.e., it defines a Container, or is a CRD with an image\_json\_path). Each of these objects becomes a resource.
 
-You can configure a resource with a call to `k8s_resource`. Today there are two relevant configuration arguments: `image` and `port_forwards`.
+You can configure a resource with a call to [`k8s_resource`](api.html#api.k8s_resource). Today there are two relevant configuration arguments: `new_name` and `port_forwards`.
 
-`image` allows you to specify a custom image to group by. If not specified it will try to group images by the name of the resource itself.
+`new_name` allows you to specify a new resource name, in case you do not like the automatically generated one.
 
 ```python
-# group pods running images named "Frontend" in to a resource named "frontend"
-k8s_resource('frontend')
-
-# group pods running images named "custom_frontend" in to a resource named "frontend"
-k8s_resource('frontend', image='custom_frontend')
+# rename the resource "redis:deployment" to "redis"
+k8s_resource('redis:deployment', new_name='redis')
 ```
 
 Tilt also supports a few ways to specify `port_forwards`:

--- a/docs/tiltfile_concepts.md
+++ b/docs/tiltfile_concepts.md
@@ -127,10 +127,15 @@ docker_build("companyname/frontend", "frontend", build_args={"target": "local"})
 
 You can combine multiple optional arguments.
 
+## Workloads
+
+A workload is roughly a Kubernetes object that has a container. This means it's running an
+image and might produce logs and have some kind of status.
+
 ## Resources
 Tilt's UI makes it easier to find errors by grouping related status and output. E.g., when you edit a file, you want to know what error it caused, whether it's an error at build-time, deploy-time, or run-time. Tilt calls these groupings "Resources". Each Resource has a line in the UI that can be expanded and investigated.
 
-Tilt generates these groups after executing your `Tiltfile`. It does this by scanning all loaded yaml for any k8s objects that it considers a "workload" (i.e., it defines a Container, or is a CRD with an image\_json\_path). Each of these objects becomes a resource.
+Tilt generates these groups after executing your `Tiltfile`. It does this by scanning all loaded yaml for any k8s objects that it considers a workload. Each of these workloads becomes a Tilt resource.
 
 You can configure a resource with a call to [`k8s_resource`](api.html#api.k8s_resource). Today there are two relevant configuration arguments: `new_name` and `port_forwards`.
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -68,9 +68,9 @@ Tilt can give you consistent port forwards to running pods (whether they're runn
 k8s_resource('frontend', port_forwards='9000')
 ```
 
-(Note that the first parameter of `k8s_resource` must match the name of an image that was built. If you'd like to name it something else you can use the [`image` parameter](api.html#api.k8s_resource) to manually specify an image to group by)
+(Note that the first parameter of `k8s_resource` must match the name of a pod-having k8s object that was passed to `k8s_yaml`. If you'd like to name it something else you can use the [`new_name` parameter](api.html#api.k8s_resource) to change its name.)
 
-You can also use `k8s_resource` to change the resource grouping, or forward multiple ports. Cf. the [Resources](tiltfile_concepts.html#resources) section of `Tiltfile Concepts`.
+You can also use `k8s_resource` to forward multiple ports. Cf. the [Resources](tiltfile_concepts.html#resources) section of `Tiltfile Concepts`.
 
 ## Congrats
 Tilt is now setup for your project. Try exploring Tilt's UI (there's a context-sensitive legend in the bottom right). Introduce a build error and then a runtime crash; see Tilt's UI respond and surface the relevant problem.

--- a/src/_includes/api.html
+++ b/src/_includes/api.html
@@ -304,8 +304,68 @@ This uses the k8s json path template syntax, described <a class="reference exter
 </table>
 </dd></dl><dl class="function">
 <dt id="api.k8s_resource">
-<code class="descclassname">api.</code><code class="descname">k8s_resource</code><span class="sig-paren">(</span><em>name</em>, <em>yaml=&apos;&apos;</em>, <em>image=&apos;&apos;</em>, <em>port_forwards=[]</em>, <em>extra_pod_selectors=[]</em><span class="sig-paren">)</span><a class="headerlink" href="#api.k8s_resource" title="Permalink to this definition">&#xB6;</a></dt>
-<dd><p>Creates a kubernetes resource that tilt can deploy using the specified image.</p>
+<code class="descclassname">api.</code><code class="descname">k8s_resource</code><span class="sig-paren">(</span><em>workload</em>, <em>new_name=&apos;&apos;</em>, <em>port_forwards=[]</em>, <em>extra_pod_selectors=[]</em><span class="sig-paren">)</span><a class="headerlink" href="#api.k8s_resource" title="Permalink to this definition">&#xB6;</a></dt>
+<dd><p>Configures a kubernetes resources</p>
+<p>If <a class="reference internal" href="#api.k8s_resource_assembly_version" title="api.k8s_resource_assembly_version"><code class="xref py py-meth docutils literal notranslate"><span class="pre">k8s_resource_assembly_version()</span></code></a> has been called with <cite>1</cite>, see
+<a class="reference internal" href="#api.k8s_resource_v1_DEPRECATED" title="api.k8s_resource_v1_DEPRECATED"><code class="xref py py-meth docutils literal notranslate"><span class="pre">k8s_resource_v1_DEPRECATED()</span></code></a> instead.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name">
+<col class="field-body">
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
+<li><strong>workload</strong> (<code class="xref py py-class docutils literal notranslate"><span class="pre">str</span></code>) &#x2013; which workload&#x2019;s resource to configure. This is a colon-separated
+string consisting of one or more of (name, kind, namespace, group), e.g.,
+&#x201C;redis&#x201D;, &#x201C;redis:deployment&#x201D;, or &#x201C;redis:deployment:default&#x201D;.
+<cite>k8s_resource</cite> searches all loaded k8s workload objects for an object matching
+all given fields. If there&#x2019;s exactly one, <cite>k8s_resource</cite> configures options for
+that workload. If there&#x2019;s not exactly one, <cite>k8s_resource</cite> raises an error.
+(e.g., &#x201C;redis&#x201D; suffices if there&#x2019;s only one object named &#x201C;redis&#x201D;, but if
+there&#x2019;s both a deployment and a cronjob named &#x201C;redis&#x201D;, you&#x2019;d need to specify
+&#x201C;redis:deployment&#x201D;).</li>
+<li><strong>new_name</strong> (<code class="xref py py-class docutils literal notranslate"><span class="pre">str</span></code>) &#x2013; if non-empty, will be used as the new name for this resource</li>
+<li><strong>port_forwards</strong> (<code class="xref py py-data docutils literal notranslate"><span class="pre">Union</span></code>[<code class="xref py py-class docutils literal notranslate"><span class="pre">str</span></code>, <code class="xref py py-class docutils literal notranslate"><span class="pre">int</span></code>, <code class="xref py py-class docutils literal notranslate"><span class="pre">List</span></code>[<code class="xref py py-class docutils literal notranslate"><span class="pre">int</span></code>]]) &#x2013; Local ports to connect to the pod. If no
+target port is specified, will use the first container port.
+Example values: 9000 (connect localhost:9000 to the default container port),
+&#x2018;9000:8000&#x2019; (connect localhost:9000 to the container port 8000),
+[&#x2018;9000:8000&#x2019;, &#x2018;9001:8001&#x2019;] (connect localhost:9000 and :9001 to the
+container ports 8000 and 8001, respectively).</li>
+<li><strong>extra_pod_selectors</strong> (<code class="xref py py-data docutils literal notranslate"><span class="pre">Union</span></code>[<code class="xref py py-class docutils literal notranslate"><span class="pre">Dict</span></code>[<code class="xref py py-class docutils literal notranslate"><span class="pre">str</span></code>, <code class="xref py py-class docutils literal notranslate"><span class="pre">str</span></code>], <code class="xref py py-class docutils literal notranslate"><span class="pre">List</span></code>[<code class="xref py py-class docutils literal notranslate"><span class="pre">Dict</span></code>[<code class="xref py py-class docutils literal notranslate"><span class="pre">str</span></code>, <code class="xref py py-class docutils literal notranslate"><span class="pre">str</span></code>]]]) &#x2013; In addition to relying on Tilt&#x2019;s heuristics to automatically
+find K8S resources associated with this resource, a user may specify extra
+labelsets to force entities to be associated with this resource. An entity
+will be associated with this resource if it has all of the labels in at
+least one of the entries specified (but still also if it meets any of
+Tilt&#x2019;s usual mechanisms).</li>
+</ul>
+</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Return type:</th><td class="field-body"><p class="first last"><code class="docutils literal notranslate"><span class="pre">None</span></code></p>
+</td>
+</tr>
+</tbody>
+</table>
+</dd></dl><dl class="function">
+<dt id="api.k8s_resource_assembly_version">
+<code class="descclassname">api.</code><code class="descname">k8s_resource_assembly_version</code><span class="sig-paren">(</span><em>version</em><span class="sig-paren">)</span><a class="headerlink" href="#api.k8s_resource_assembly_version" title="Permalink to this definition">&#xB6;</a></dt>
+<dd><p>Specifies which version of k8s resource assembly loading to use.</p>
+<p>This function is deprecated and will be removed.
+See <a class="reference external" href="/resource_assembly_migration.html">Resource Assembly Migration</a> for information.</p>
+<p>Changes the behavior of <a class="reference internal" href="#api.k8s_resource" title="api.k8s_resource"><code class="xref py py-meth docutils literal notranslate"><span class="pre">k8s_resource()</span></code></a>.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name">
+<col class="field-body">
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body"><code class="docutils literal notranslate"><span class="pre">None</span></code></td>
+</tr>
+</tbody>
+</table>
+</dd></dl><dl class="function">
+<dt id="api.k8s_resource_v1_DEPRECATED">
+<code class="descclassname">api.</code><code class="descname">k8s_resource_v1_DEPRECATED</code><span class="sig-paren">(</span><em>name</em>, <em>yaml=&apos;&apos;</em>, <em>image=&apos;&apos;</em>, <em>port_forwards=[]</em>, <em>extra_pod_selectors=[]</em><span class="sig-paren">)</span><a class="headerlink" href="#api.k8s_resource_v1_DEPRECATED" title="Permalink to this definition">&#xB6;</a></dt>
+<dd><p>NOTE: This is actually named <a class="reference internal" href="#api.k8s_resource" title="api.k8s_resource"><code class="xref py py-meth docutils literal notranslate"><span class="pre">k8s_resource()</span></code></a>. This documents
+the behavior of this method after a call to <a class="reference internal" href="#api.k8s_resource_assembly_version" title="api.k8s_resource_assembly_version"><code class="xref py py-meth docutils literal notranslate"><span class="pre">k8s_resource_assembly_version()</span></code></a> with value <cite>1</cite>.
+This behavior is deprecated and will be removed.
+See <a class="reference external" href="/resource_assembly_migration.html">Resource Assembly Migration</a> for information.</p>
+<p>Creates a kubernetes resource that tilt can deploy using the specified image.</p>
 <table class="docutils field-list" frame="void" rules="none">
 <col class="field-name">
 <col class="field-body">

--- a/src/_includes/api.html
+++ b/src/_includes/api.html
@@ -227,11 +227,11 @@ returns the non-matching YAML as the second return value.</p>
 <p>For example, if you have a file of <em>all</em> your YAML, but only want to pass a few elements to Tilt:</p>
 <div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="c1"># extract all YAMLs matching labels &quot;app=foobar&quot;</span>
 <span class="n">foobar_yaml</span><span class="p">,</span> <span class="n">rest</span> <span class="o">=</span> <span class="n">filter_yaml</span><span class="p">(</span><span class="s1">&apos;all.yaml&apos;</span><span class="p">,</span> <span class="n">labels</span><span class="o">=</span><span class="p">{</span><span class="s1">&apos;app&apos;</span><span class="p">:</span> <span class="s1">&apos;foobar&apos;</span><span class="p">}</span>
-<span class="n">k8s_resource</span><span class="p">(</span><span class="s1">&apos;foobar&apos;</span><span class="p">,</span> <span class="n">yaml</span><span class="o">=</span><span class="n">foobar_yaml</span><span class="p">)</span>
+<span class="n">k8s_yaml</span><span class="p">(</span><span class="n">foobar_yaml</span><span class="p">)</span>
 
 <span class="c1"># extract YAMLs of kind &quot;deployment&quot; with metadata.name &quot;baz&quot;</span>
 <span class="n">baz_yaml</span><span class="p">,</span> <span class="n">rest</span> <span class="o">=</span> <span class="n">filter_yaml</span><span class="p">(</span><span class="n">rest</span><span class="p">,</span> <span class="n">name</span><span class="o">=</span><span class="s1">&apos;baz&apos;</span><span class="p">,</span> <span class="n">kind</span><span class="o">=</span><span class="s1">&apos;deployment&apos;</span><span class="p">)</span>
-<span class="n">k8s_resource</span><span class="p">(</span><span class="s1">&apos;baz&apos;</span><span class="p">,</span> <span class="n">yaml</span><span class="o">=</span><span class="n">baz_yaml</span><span class="p">)</span>
+<span class="n">k8s_yaml</span><span class="p">(</span><span class="n">baz_yaml</span><span class="p">)</span>
 </pre></div>
 </div>
 <table class="docutils field-list" frame="void" rules="none">


### PR DESCRIPTION
1. Documenting old `k8s_resource` behavior as `k8s_resource_v1_DEPRECATED` is a bit janky, but I haven't thought of a less bad option.
2. Tossing 2019-05-01 out there as a stake in the ground for removing support for the old behavior.