### PR TITLE
fix typo in live update docs and update docker_compose docs

### DIFF
--- a/docs/docker_compose.md
+++ b/docs/docker_compose.md
@@ -62,7 +62,7 @@ adds the NodeJS dependencies, then adds the source code.
 
 ```dockerfile
 FROM node:9-alpine
-WORKDIR '/var/www/app'
+WORKDIR /var/www/app
 ADD package.json .
 RUN npm install
 ADD . .
@@ -100,13 +100,44 @@ docker_build('tilt.dev/express-redis-app', '.')
 ```
 
 Now, when we run `tilt up`, Tilt will manage the image builds
-and re-build correctly every time a file changes.
+and re-build every time a file changes.
 
-You can also use Tilt's [Live Update](live_update_tutorial.html) feature to sync and build inside running containers.
+## Using Tilt's `live_update`
+
+This works OK. But building a new image on every change can be a drag.
+
+With the `live_update` option, we can make it a lot faster by updating the container in-place.
+
+Here's the new Tiltfile:
+
+```python
+docker_compose('docker-compose.yml')
+docker_build('tilt.dev/express-redis-app', '.',
+  live_update = [
+    sync('.', '/var/www/app'),
+    run('npm i', trigger='package.json'),
+    restart_container()
+  ])
+```
+
+The `live_update` option is expressed as a sequence of in-place update steps.
+
+1. The `sync` step copies your local files into the running container.
+
+2. The `run` step re-runs `npm i` inside the container every time you edit `package.json`.
+
+3. The `restart_container` step restarts the server so that your changes are picked up.
+
+For more info on `live_update`, check out the [full tutorial](live_update_tutorial.html).
 
 ## Debugging
 
 Tilt uses Docker Compose to run your services, so you can also use `docker-compose` to examine state outside Tilt.
+
+## Try it Yourself
+
+All the code in this tutorial is available in [this Git repo](https://github.com/windmilleng/express-redis-docker).
+Run it yourself and make changes to see how it works.
 
 ## Troubleshooting
 

--- a/docs/live_update_reference.md
+++ b/docs/live_update_reference.md
@@ -12,13 +12,13 @@ The list of `LiveUpdateSteps` must be, in order:
 - 0 or more [`fall_back_on`](api.html#api.fall_back_on)
 - 0 or more [`sync`](api.html#api.sync)
 - 0 or more [`run`](api.html#api.run)
-- 0 or 1 [`container_restart`](api.html#api.container_restart)
+- 0 or 1 [`restart_container`](api.html#api.restart_container)
 
-When a file changes:	
-   1. If it matches any of the files in a `fall_back_on` step, we will fall back to a full rebuild + deploy (i.e., the normal, non-live_update process).	
-   2. Otherwise, if it matches any of the local paths in `sync` steps, a live update will be executed:	
-        1. copy any changed files according to `sync` steps	
+When a file changes:
+   1. If it matches any of the files in a `fall_back_on` step, we will fall back to a full rebuild + deploy (i.e., the normal, non-live_update process).
+   2. Otherwise, if it matches any of the local paths in `sync` steps, a live update will be executed:
+        1. copy any changed files according to `sync` steps
         2. for every `run` step:
             * if the `run` specifies one or more `triggers`, execute the command iff any changed files match the given triggers
             * else, simply execute the command
-        3. restart the container if a `container_restart` step is present. (This is tantamount to re-executing the container's `ENTRYPOINT`.)
+        3. restart the container if a `restart_container` step is present. (This is tantamount to re-executing the container's `ENTRYPOINT`.)


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/restart:

839470b685ef0ec7e488ba8265753d3937199cfe (2019-04-12 16:57:30 -0400)
fix typo in live update docs and update docker_compose docs