### PR TITLE
api: remove k8s_kind from custom_build example

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -384,8 +384,6 @@ def custom_build(ref: str, command: str, deps: List[str], tag: str = "", disable
 
   Example ::
 
-    k8s_yaml('deploy/fission.yaml')
-    k8s_kind('Environment', image_json_path='{.spec.runtime.image}')
     custom_build(
       'gcr.io/foo',
       'docker build -t $EXPECTED_REF .',

--- a/src/_includes/api.html
+++ b/src/_includes/api.html
@@ -179,9 +179,7 @@
 <p>Returns an object which can be used to create a FastBuild.</p>
 <p>It will raise an error if the specified ref is not published in the registry with the name+tag that is provided via the <code class="docutils literal notranslate"><span class="pre">$EXPECTED_REF</span></code> environment variable.</p>
 <p>Example</p>
-<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="n">k8s_yaml</span><span class="p">(</span><span class="s1">&apos;deploy/fission.yaml&apos;</span><span class="p">)</span>
-<span class="n">k8s_kind</span><span class="p">(</span><span class="s1">&apos;Environment&apos;</span><span class="p">,</span> <span class="n">image_json_path</span><span class="o">=</span><span class="s1">&apos;{.spec.runtime.image}&apos;</span><span class="p">)</span>
-<span class="n">custom_build</span><span class="p">(</span>
+<div class="highlight-default notranslate"><div class="highlight"><pre><span></span><span class="n">custom_build</span><span class="p">(</span>
   <span class="s1">&apos;gcr.io/foo&apos;</span><span class="p">,</span>
   <span class="s1">&apos;docker build -t $EXPECTED_REF .&apos;</span><span class="p">,</span>
   <span class="p">[</span><span class="s1">&apos;.&apos;</span><span class="p">],</span>


### PR DESCRIPTION
I'm guessing this is copypasta from the k8s_kind example.