### PR TITLE
Removing extra `)`

### DIFF
--- a/docs/nodejs_microservice_hotreloading.md
+++ b/docs/nodejs_microservice_hotreloading.md
@@ -28,7 +28,6 @@ docker_build('tilt-frontend-demo', '.',
     # Map the local source code into the container under /src
     sync('.', '/src'),
   ])
-)
 ```
 
 This is fast, but has a bug: when you change `package.json`, the dependencies don't get updated. Let's use the fall back feature of Live Update to fix that:


### PR DESCRIPTION
It seems there is an extra `)`.  If copied and pasted, this will turn into a parsing issue. Hoping to remove