### PR TITLE
fix a typo in the frontend doc

### DIFF
--- a/docs/nodejs_microservice_hotreloading.md
+++ b/docs/nodejs_microservice_hotreloading.md
@@ -44,7 +44,7 @@ docker_build('tilt-frontend-demo', '.',
 ```
 
 
-Now we’re cruising! Updates that don't require a `bundle update` zoom by in less than a second.
+Now we’re cruising! Updates that don't require a `npm install` zoom by in less than a second.
 
 ## Further Reading
 * The full [example Tiltfile](https://github.com/windmilleng/tilt-frontend-demo/blob/master/Tiltfile) featured in this guide


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/typo:

9630f70c6d1ad1062e731a3057a0b7acd6e4b2ca (2019-04-26 13:42:25 -0400)
fix a typo in the frontend doc