### PR TITLE
api: docs for new read_yaml func

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -326,18 +326,30 @@ def k8s_kind(kind: str, api_version: str=None, *, image_json_path: Union[str, Li
   """
   pass
 
-JSONType = Union[
+StructuredDataType = Union[
     Dict[str, Any],
     List[Any],
 ]
 
-def decode_json(json: str) -> JSONType:
+def decode_json(json: str) -> StructuredDataType:
   """Deserializes a given string from JSON to Starlark. Fails if the string can't be parsed as JSON."""
   pass
 
-def read_json(path: str, default: str = None) -> JSONType:
+def read_json(path: str, default: str = None) -> StructuredDataType:
   """
   Reads the file at `path` and deserializes its contents as JSON
+
+  If the `path` does not exist and `default` is not `None`, `default` will be returned.
+  In any other case, an error reading `path` will be a Tiltfile load error.
+
+  Args:
+    path: Path to the file locally (absolute, or relative to the location of the Tiltfile).
+    default: If not `None` and the file at `path` does not exist, this value will be returned."""
+  pass
+
+def read_yaml(path: str, default: str = None) -> StructuredDataType:
+  """
+  Reads the file at `path` and deserializes its contents as YAML
 
   If the `path` does not exist and `default` is not `None`, `default` will be returned.
   In any other case, an error reading `path` will be a Tiltfile load error.

--- a/src/_includes/api.html
+++ b/src/_includes/api.html
@@ -613,6 +613,27 @@ In any other case, an error reading <cite>path</cite> will be a Tiltfile load er
 </tbody>
 </table>
 </dd></dl><dl class="function">
+<dt id="api.read_yaml">
+<code class="descclassname">api.</code><code class="descname">read_yaml</code><span class="sig-paren">(</span><em>path</em>, <em>default=None</em><span class="sig-paren">)</span><a class="headerlink" href="#api.read_yaml" title="Permalink to this definition">&#xB6;</a></dt>
+<dd><p>Reads the file at <cite>path</cite> and deserializes its contents as YAML</p>
+<p>If the <cite>path</cite> does not exist and <cite>default</cite> is not <cite>None</cite>, <cite>default</cite> will be returned.
+In any other case, an error reading <cite>path</cite> will be a Tiltfile load error.</p>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name">
+<col class="field-body">
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
+<li><strong>path</strong> (<code class="xref py py-class docutils literal notranslate"><span class="pre">str</span></code>) &#x2013; Path to the file locally (absolute, or relative to the location of the Tiltfile).</li>
+<li><strong>default</strong> (<code class="xref py py-data docutils literal notranslate"><span class="pre">Optional</span></code>[<code class="xref py py-class docutils literal notranslate"><span class="pre">str</span></code>]) &#x2013; If not <cite>None</cite> and the file at <cite>path</cite> does not exist, this value will be returned.</li>
+</ul>
+</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Return type:</th><td class="field-body"><p class="first last"><code class="xref py py-data docutils literal notranslate"><span class="pre">Union</span></code>[<code class="xref py py-class docutils literal notranslate"><span class="pre">Dict</span></code>[<code class="xref py py-class docutils literal notranslate"><span class="pre">str</span></code>, <code class="xref py py-data docutils literal notranslate"><span class="pre">Any</span></code>], <code class="xref py py-class docutils literal notranslate"><span class="pre">List</span></code>[<code class="xref py py-data docutils literal notranslate"><span class="pre">Any</span></code>]]</p>
+</td>
+</tr>
+</tbody>
+</table>
+</dd></dl><dl class="function">
 <dt id="api.run">
 <code class="descclassname">api.</code><code class="descname">run</code><span class="sig-paren">(</span><em>cmd</em>, <em>trigger=[]</em><span class="sig-paren">)</span><a class="headerlink" href="#api.run" title="Permalink to this definition">&#xB6;</a></dt>
 <dd><p>Specify that the given <cite>cmd</cite> should be executed when updating an image&#x2019;s container</p>


### PR DESCRIPTION
Hello @dmiller, @lredd,

Please review the following commits I made in branch maiamcc/read-yaml-api-doc:

f2c341048ac5b9e2b27bd4246adeebc289edd929 (2019-05-01 11:18:43 -0400)
api: docs for new read_yaml func

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics