### PR TITLE
don't use globs because it hurts docker caching

### DIFF
--- a/blog.dockerfile
+++ b/blog.dockerfile
@@ -6,7 +6,8 @@ WORKDIR /blog
 
 RUN mkdir -p /src
 RUN mkdir -p /blog
-ADD src/Gemfile* /src/
+ADD src/Gemfile /src/
+ADD src/Gemfile.lock /src/
 # work around https://github.com/windmilleng/tilt.build/issues/101
 ADD blog/Gemfile /blog/
 ADD blog/Gemfile.lock /blog/

--- a/docs.dockerfile
+++ b/docs.dockerfile
@@ -6,7 +6,8 @@ WORKDIR /docs
 
 RUN mkdir -p /src
 RUN mkdir -p /docs
-ADD src/Gemfile* /src/
+ADD src/Gemfile /src/
+ADD src/Gemfile.lock /src/
 # work around https://github.com/windmilleng/tilt.build/issues/101
 ADD docs/Gemfile /docs/
 ADD docs/Gemfile.lock /docs/

--- a/site.dockerfile
+++ b/site.dockerfile
@@ -4,7 +4,8 @@ RUN gem install jekyll bundler
 
 WORKDIR /src
 
-ADD ./Gemfile* /src/
+ADD ./Gemfile /src/
+ADD ./Gemfile.lock /src/
 RUN bundle install
 ADD . .
 ENTRYPOINT bundle exec jekyll serve --config _config.yml,_config-dev.yml


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/dockerfile:

db140d9047eb77da963614b163c2a2e462e20b02 (2019-05-15 16:04:01 -0400)
don't use globs because it hurts docker caching