### PR TITLE
form: make options squares instead of circles

### DIFF
--- a/src/_sass/layout.scss
+++ b/src/_sass/layout.scss
@@ -951,10 +951,13 @@ input[type=checkbox] {
   top: 0;
   left: 0;
   display: inline-block;
-  width: $spacing-unit * 1.5;
-  height: $spacing-unit * 1.5;
+  margin-left: 0.25 * $spacing-unit;
+  margin-top: 0.125 * $spacing-unit;
+  width: $spacing-unit * 1.25;
+  height: $spacing-unit * 1.25;
   background-color: $color-grey-lightest;
-  border-radius: $spacing-unit * 0.75;
+  border-radius: 3px;
+  border: 1px solid $color-grey-dark;
   transition: background-color 0.2s ease-in-out;
   pointer-events: none;
 }


### PR DESCRIPTION
Hello @yuindustries,

Please review the following commits I made in branch nicks/squares:

29e153b6cc89903cad30fcb5fc9f1166b3901f16 (2019-05-15 16:04:57 -0400)
form: make options squares instead of circles