### PR TITLE
api: note that fast_build is deprecated rather than linking to non-existant docs

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -108,7 +108,7 @@ class FastBuild:
 def fast_build(img_name: str, dockerfile_path: str, entrypoint: str = "") -> FastBuild:
   """Initiates a docker image build that supports ``add`` s and ``run`` s, and that uses a cache for subsequent builds.
 
-    See the `fast build documentation <https://docs.tilt.dev/fast_build.html>`_.
+  **Note**: this is a deprecated feature. For the fast building of the future, check out our `LiveUpdate tutorial </live_update_tutorial.html>`_ and `reference documention </live_update_reference.html>`_.
   """
   pass
 

--- a/src/_includes/api.html
+++ b/src/_includes/api.html
@@ -311,7 +311,7 @@ an error will be raised.)</p>
 <dt id="api.fast_build">
 <code class="descclassname">api.</code><code class="descname">fast_build</code><span class="sig-paren">(</span><em>img_name</em>, <em>dockerfile_path</em>, <em>entrypoint=&apos;&apos;</em><span class="sig-paren">)</span><a class="headerlink" href="#api.fast_build" title="Permalink to this definition">&#xB6;</a></dt>
 <dd><p>Initiates a docker image build that supports <code class="docutils literal notranslate"><span class="pre">add</span></code> s and <code class="docutils literal notranslate"><span class="pre">run</span></code> s, and that uses a cache for subsequent builds.</p>
-<p>See the <a class="reference external" href="https://docs.tilt.dev/fast_build.html">fast build documentation</a>.</p>
+<p><strong>Note</strong>: this is a deprecated feature. For the fast building of the future, check out our <a class="reference external" href="/live_update_tutorial.html">LiveUpdate tutorial</a> and <a class="reference external" href="/live_update_reference.html">reference documention</a>.</p>
 <table class="docutils field-list" frame="void" rules="none">
 <col class="field-name">
 <col class="field-body">


### PR DESCRIPTION
Fixes #153