### PR TITLE
k8s: add readiness probes to jekyll servers

### DIFF
--- a/serve.yaml
+++ b/serve.yaml
@@ -16,6 +16,11 @@ spec:
         image: tilt-site
         ports:
         - containerPort: 4000
+          name: http
+        readinessProbe:
+          httpGet:
+            path: /
+            port: http
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -35,6 +40,11 @@ spec:
         image: docs-site
         ports:
         - containerPort: 4000
+          name: http
+        readinessProbe:
+          httpGet:
+            path: /
+            port: http
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -54,3 +64,8 @@ spec:
         image: blog-site
         ports:
         - containerPort: 4000
+          name: http
+        readinessProbe:
+          httpGet:
+            path: /
+            port: http


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/probe:

69c2e93cd4328678bc5c0f56293c4de6040677de (2019-06-13 12:18:33 -0400)
k8s: add readiness probes to jekyll servers