### PR TITLE
Revert "k8s: add readiness probes to jekyll servers (#173)"

### DIFF
--- a/serve.yaml
+++ b/serve.yaml
@@ -16,11 +16,6 @@ spec:
         image: tilt-site
         ports:
         - containerPort: 4000
-          name: http
-        readinessProbe:
-          httpGet:
-            path: /
-            port: http
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -40,11 +35,6 @@ spec:
         image: docs-site
         ports:
         - containerPort: 4000
-          name: http
-        readinessProbe:
-          httpGet:
-            path: /
-            port: http
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -64,8 +54,3 @@ spec:
         image: blog-site
         ports:
         - containerPort: 4000
-          name: http
-        readinessProbe:
-          httpGet:
-            path: /
-            port: http


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/health:

5da730982229f914fb6823b1ea90ed003e1e1d41 (2019-06-13 17:34:30 -0400)
Revert "k8s: add readiness probes to jekyll servers (#173)"
This reverts commit 6161f6f6c9f6007283a30349bb45291479294644.