### PR TITLE
remove jekyll build health check. this is too slow

### DIFF
--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -5,5 +5,3 @@ set -ex
 # check to make sure Jekyll is serving
 curl localhost:4000
 
-# check to make sure Jekyll doesn't have any errors
-bundle exec jekyll build --config _config.yml,_config-dev.yml


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/health2:

62f0dd2bc1fba008bec581346c1bb01a8e1ae52c (2019-06-24 11:25:49 -0400)
remove jekyll build health check. this is too slow