### PR TITLE
docs: link to scripts to spoof restart_container on non-docker runtimes [ch2861]

### DIFF
--- a/docs/live_update_reference.md
+++ b/docs/live_update_reference.md
@@ -116,3 +116,5 @@ docker_build('my-img', '.', live_update=[
 This step is optional. If you have a `restart_container` step, it must come at the very end of your list of Live Update steps. When this step is present, it tells Tilt to restart the container after all the files have been sync'd, runs have been executed, etc. In practice, this means that the container re-executes its `ENTRYPOINT` within the changed filesystem.
 
 If your container executes a binary and your Live Update changes that binary, you probably want to restart the container to re-execute it. If, however, you're running a Flask or Node app that responds to filesystem changes without requiring a restart, you can probably leave this step out.
+
+**NOTE**: `restart_container()` *only* works on containers managed by Docker. For non-Docker runtimes (e.g. containerd, CRI-O), please see the [wrapper script for simulating restart_container](https://github.com/windmilleng/rerun-process-wrapper).


### PR DESCRIPTION
Hello @nicks, @dbentley,

Please review the following commits I made in branch maiamcc/spoof-container-restart:

7ba7d4f360724517dd5a9cd4beaf472953413362 (2019-07-05 17:06:38 -0400)
docs: link to scripts to spoof restart_container on non-docker runtimes [ch2861]

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics