### PR TITLE
api: entrypoint param for docker_build and custom_build [ch2886]

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -60,7 +60,7 @@ def container_restart() -> LiveUpdateStep:
   """
   pass
 
-def docker_build(ref: str, context: str, build_args: Dict[str, str] = {}, dockerfile: str = "Dockerfile", dockerfile_contents: Union[str, Blob] = "", live_update: List[LiveUpdateStep]=[], ignore: Union[str, List[str]] = [], only: Union[str, List[str]] = []) -> None:
+def docker_build(ref: str, context: str, build_args: Dict[str, str] = {}, dockerfile: str = "Dockerfile", dockerfile_contents: Union[str, Blob] = "", live_update: List[LiveUpdateStep]=[], ignore: Union[str, List[str]] = [], only: Union[str, List[str]] = [], entrypoint: str = "") -> None:
   """Builds a docker image.
 
   Note that you can't set both the `dockerfile` and `dockerfile_contents` arguments (will throw an error).
@@ -68,6 +68,8 @@ def docker_build(ref: str, context: str, build_args: Dict[str, str] = {}, docker
   Example: ``docker_build('myregistry/myproj/backend', '/path/to/code')`` is roughly equivalent to the call ``docker build /path/to/code -t myregistry/myproj/backend``
 
   Note: If you're using the the `ignore` and `only` parameters to do context filtering and you have tricky cases, reach out to us. The implementation is complex and there might be edge cases.
+
+  Note: the `entrypoint` parameter is not supported for Docker Compose resources. If you need it for your use case, let us know.
 
   Args:
     ref: name for this image (e.g. 'myproj/backend' or 'myregistry/myproj/backend'). If this image will be used in a k8s resource(s), this ref must match the ``spec.container.image`` param for that resource(s).
@@ -78,6 +80,7 @@ def docker_build(ref: str, context: str, build_args: Dict[str, str] = {}, docker
     live_update: set of steps for updating a running container (see `Live Update documentation <live_update_reference.html>`_).
     ignore: set of file patterns that will be ignored. Ignored files will not trigger builds and will not be included in images. Follows the `dockerignore syntax <https://docs.docker.com/engine/reference/builder/#dockerignore-file>`_.
     only: set of file patterns that will cause a build to be triggered. All other changes will be ignored. Inverse of ignore parameter. Follows the `dockerignore syntax <https://docs.docker.com/engine/reference/builder/#dockerignore-file>`_. Note that ignores take precedence over this parameter.
+    entrypoint: command to run when this container starts. Takes precedence over the container's ``CMD`` or ``ENTRYPOINT``, and over a `container command specified in k8s YAML <https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/>`_. Will be evaluated in a shell context: e.g. ``entrypoint="foo.sh bar"`` will be executed in the container as ``/bin/sh -c 'foo.sh bar'``.
   """
   pass
 
@@ -427,12 +430,12 @@ def default_registry(registry: str) -> None:
   pass
 
 class CustomBuild:
-  """An image that was created with ``custom_build``"""
+  """An image that was created with :meth:`custom_build`"""
   def add_fast_build() -> FastBuild:
     """Returns a FastBuild that is associated with the image that was built from a ``custom_build``. When the container needs to be rebuilt it will be built using the ``CustomBuild``. Otherwise update will be done with the ``FastBuild`` instructions. """
     pass
 
-def custom_build(ref: str, command: str, deps: List[str], tag: str = "", disable_push: bool = False, live_update: List[LiveUpdateStep]=[]) -> CustomBuild:
+def custom_build(ref: str, command: str, deps: List[str], tag: str = "", disable_push: bool = False, live_update: List[LiveUpdateStep]=[], entrypoint: str="") -> CustomBuild:
   """Provide a custom command that will build an image.
 
   Returns an object which can be used to create a FastBuild.
@@ -450,6 +453,8 @@ def custom_build(ref: str, command: str, deps: List[str], tag: str = "", disable
       ['.'],
     )
 
+  Note: the `entrypoint` parameter is not supported for Docker Compose resources. If you need it for your use case, let us know.
+
   Args:
     ref: name for this image (e.g. 'myproj/backend' or 'myregistry/myproj/backend'). If this image will be used in a k8s resource(s), this ref must match the ``spec.container.image`` param for that resource(s).
     command: a command that, when run in the shell, builds an image puts it in the registry as ``ref``. Must produce an image named ``$EXPECTED_REF``
@@ -458,6 +463,7 @@ def custom_build(ref: str, command: str, deps: List[str], tag: str = "", disable
        then re-tag it with its own tag before pushing to your cluster. See `the bazel guide <integrating_bazel_with_tilt.html>`_ for an example.
     disable_push: whether Tilt should push the image in to the registry that the Kubernetes cluster has access to. Set this to true if your command handles pushing as well.
     live_update: set of steps for updating a running container (see `Live Update documentation <live_update_reference.html>`_).
+    entrypoint: command to run when this container starts. Takes precedence over the container's ``CMD`` or ``ENTRYPOINT``, and over a `container command specified in k8s YAML <https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/>`_. Will be evaluated in a shell context: e.g. ``entrypoint="foo.sh bar"`` will be executed in the container as ``/bin/sh -c 'foo.sh bar'``.
   """
   pass
 

--- a/src/_includes/api.html
+++ b/src/_includes/api.html
@@ -7,7 +7,7 @@
 </dd></dl><dl class="class">
 <dt id="api.CustomBuild">
 <em class="property">class </em><code class="descclassname">api.</code><code class="descname">CustomBuild</code><a class="headerlink" href="#api.CustomBuild" title="Permalink to this definition">&#xB6;</a></dt>
-<dd><p>An image that was created with <code class="docutils literal notranslate"><span class="pre">custom_build</span></code></p>
+<dd><p>An image that was created with <a class="reference internal" href="#api.custom_build" title="api.custom_build"><code class="xref py py-meth docutils literal notranslate"><span class="pre">custom_build()</span></code></a></p>
 <dl class="method">
 <dt id="api.CustomBuild.add_fast_build">
 <code class="descname">add_fast_build</code><span class="sig-paren">(</span><span class="sig-paren">)</span><a class="headerlink" href="#api.CustomBuild.add_fast_build" title="Permalink to this definition">&#xB6;</a></dt>
@@ -186,7 +186,7 @@ Possible values are:</p>
 </table>
 </dd></dl><dl class="function">
 <dt id="api.custom_build">
-<code class="descclassname">api.</code><code class="descname">custom_build</code><span class="sig-paren">(</span><em>ref</em>, <em>command</em>, <em>deps</em>, <em>tag=&apos;&apos;</em>, <em>disable_push=False</em>, <em>live_update=[]</em><span class="sig-paren">)</span><a class="headerlink" href="#api.custom_build" title="Permalink to this definition">&#xB6;</a></dt>
+<code class="descclassname">api.</code><code class="descname">custom_build</code><span class="sig-paren">(</span><em>ref</em>, <em>command</em>, <em>deps</em>, <em>tag=&apos;&apos;</em>, <em>disable_push=False</em>, <em>live_update=[]</em>, <em>entrypoint=&apos;&apos;</em><span class="sig-paren">)</span><a class="headerlink" href="#api.custom_build" title="Permalink to this definition">&#xB6;</a></dt>
 <dd><p>Provide a custom command that will build an image.</p>
 <p>Returns an object which can be used to create a FastBuild.</p>
 <p>The command <em>must</em> publish an image with the name &amp; tag <code class="docutils literal notranslate"><span class="pre">$EXPECTED_REF</span></code>.</p>
@@ -200,6 +200,7 @@ an image with the ref <code class="docutils literal notranslate"><span class="pr
 <span class="p">)</span>
 </pre></div>
 </div>
+<p>Note: the <cite>entrypoint</cite> parameter is not supported for Docker Compose resources. If you need it for your use case, let us know.</p>
 <table class="docutils field-list" frame="void" rules="none">
 <col class="field-name">
 <col class="field-body">
@@ -213,6 +214,7 @@ then re-tag it with its own tag before pushing to your cluster. See <a class="re
 <li><strong>disable_push</strong> (<code class="xref py py-class docutils literal notranslate"><span class="pre">bool</span></code>) &#x2013; whether Tilt should push the image in to the registry that the Kubernetes cluster has access to. Set this to true if your command handles pushing as well.</li>
 <li><strong>live_update</strong> (<code class="xref py py-class docutils literal notranslate"><span class="pre">List</span></code>[<a class="reference internal" href="#api.LiveUpdateStep" title="api.LiveUpdateStep"><code class="xref py py-class docutils literal notranslate"><span class="pre">LiveUpdateStep</span></code></a>]) &#x2013; <p>set of steps for updating a running container (see <a class="reference external" href="live_update_reference.html">Live Update documentation</a>).</p>
 </li>
+<li><strong>entrypoint</strong> (<code class="xref py py-class docutils literal notranslate"><span class="pre">str</span></code>) &#x2013; command to run when this container starts. Takes precedence over the container&#x2019;s <code class="docutils literal notranslate"><span class="pre">CMD</span></code> or <code class="docutils literal notranslate"><span class="pre">ENTRYPOINT</span></code>, and over a <a class="reference external" href="https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/">container command specified in k8s YAML</a>. Will be evaluated in a shell context: e.g. <code class="docutils literal notranslate"><span class="pre">entrypoint=&quot;foo.sh</span> <span class="pre">bar&quot;</span></code> will be executed in the container as <code class="docutils literal notranslate"><span class="pre">/bin/sh</span> <span class="pre">-c</span> <span class="pre">&apos;foo.sh</span> <span class="pre">bar&apos;</span></code>.</li>
 </ul>
 </td>
 </tr>
@@ -264,11 +266,12 @@ then re-tag it with its own tag before pushing to your cluster. See <a class="re
 </table>
 </dd></dl><dl class="function">
 <dt id="api.docker_build">
-<code class="descclassname">api.</code><code class="descname">docker_build</code><span class="sig-paren">(</span><em>ref</em>, <em>context</em>, <em>build_args={}</em>, <em>dockerfile=&apos;Dockerfile&apos;</em>, <em>dockerfile_contents=&apos;&apos;</em>, <em>live_update=[]</em>, <em>ignore=[]</em>, <em>only=[]</em><span class="sig-paren">)</span><a class="headerlink" href="#api.docker_build" title="Permalink to this definition">&#xB6;</a></dt>
+<code class="descclassname">api.</code><code class="descname">docker_build</code><span class="sig-paren">(</span><em>ref</em>, <em>context</em>, <em>build_args={}</em>, <em>dockerfile=&apos;Dockerfile&apos;</em>, <em>dockerfile_contents=&apos;&apos;</em>, <em>live_update=[]</em>, <em>ignore=[]</em>, <em>only=[]</em>, <em>entrypoint=&apos;&apos;</em><span class="sig-paren">)</span><a class="headerlink" href="#api.docker_build" title="Permalink to this definition">&#xB6;</a></dt>
 <dd><p>Builds a docker image.</p>
 <p>Note that you can&#x2019;t set both the <cite>dockerfile</cite> and <cite>dockerfile_contents</cite> arguments (will throw an error).</p>
 <p>Example: <code class="docutils literal notranslate"><span class="pre">docker_build(&apos;myregistry/myproj/backend&apos;,</span> <span class="pre">&apos;/path/to/code&apos;)</span></code> is roughly equivalent to the call <code class="docutils literal notranslate"><span class="pre">docker</span> <span class="pre">build</span> <span class="pre">/path/to/code</span> <span class="pre">-t</span> <span class="pre">myregistry/myproj/backend</span></code></p>
 <p>Note: If you&#x2019;re using the the <cite>ignore</cite> and <cite>only</cite> parameters to do context filtering and you have tricky cases, reach out to us. The implementation is complex and there might be edge cases.</p>
+<p>Note: the <cite>entrypoint</cite> parameter is not supported for Docker Compose resources. If you need it for your use case, let us know.</p>
 <table class="docutils field-list" frame="void" rules="none">
 <col class="field-name">
 <col class="field-body">
@@ -283,6 +286,8 @@ then re-tag it with its own tag before pushing to your cluster. See <a class="re
 </li>
 <li><strong>ignore</strong> (<code class="xref py py-data docutils literal notranslate"><span class="pre">Union</span></code>[<code class="xref py py-class docutils literal notranslate"><span class="pre">str</span></code>, <code class="xref py py-class docutils literal notranslate"><span class="pre">List</span></code>[<code class="xref py py-class docutils literal notranslate"><span class="pre">str</span></code>]]) &#x2013; set of file patterns that will be ignored. Ignored files will not trigger builds and will not be included in images. Follows the <a class="reference external" href="https://docs.docker.com/engine/reference/builder/#dockerignore-file">dockerignore syntax</a>.</li>
 <li><strong>only</strong> (<code class="xref py py-data docutils literal notranslate"><span class="pre">Union</span></code>[<code class="xref py py-class docutils literal notranslate"><span class="pre">str</span></code>, <code class="xref py py-class docutils literal notranslate"><span class="pre">List</span></code>[<code class="xref py py-class docutils literal notranslate"><span class="pre">str</span></code>]]) &#x2013; <p>set of file patterns that will cause a build to be triggered. All other changes will be ignored. Inverse of ignore parameter. Follows the <a class="reference external" href="https://docs.docker.com/engine/reference/builder/#dockerignore-file">dockerignore syntax</a>. Note that ignores take precedence over this parameter.</p>
+</li>
+<li><strong>entrypoint</strong> (<code class="xref py py-class docutils literal notranslate"><span class="pre">str</span></code>) &#x2013; <p>command to run when this container starts. Takes precedence over the container&#x2019;s <code class="docutils literal notranslate"><span class="pre">CMD</span></code> or <code class="docutils literal notranslate"><span class="pre">ENTRYPOINT</span></code>, and over a <a class="reference external" href="https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/">container command specified in k8s YAML</a>. Will be evaluated in a shell context: e.g. <code class="docutils literal notranslate"><span class="pre">entrypoint=&quot;foo.sh</span> <span class="pre">bar&quot;</span></code> will be executed in the container as <code class="docutils literal notranslate"><span class="pre">/bin/sh</span> <span class="pre">-c</span> <span class="pre">&apos;foo.sh</span> <span class="pre">bar&apos;</span></code>.</p>
 </li>
 </ul>
 </td>


### PR DESCRIPTION
Hello @landism, @nicks,

Please review the following commits I made in branch maiamcc/override-command:

a362d537153e11776ba5d191e5b18552fc6d6638 (2019-07-11 16:48:37 -0400)
api: entrypoint param for docker_build and custom_build

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics