### PR TITLE
doc(bazel): watch for files changes not labels.

### DIFF
--- a/docs/integrating_bazel_with_tilt.md
+++ b/docs/integrating_bazel_with_tilt.md
@@ -189,7 +189,7 @@ def bazel_build(image, target):
   custom_build(
     image,
     BAZEL_RUN_CMD % target,
-    source_deps,
+    source_deps_files,
     tag="image",
   )
 ```


### PR DESCRIPTION
Currently `custom_build` watch for just label changes on bazel workspace. This PR fixes to watch for source file changes

fixes #236 