### PR TITLE
Fix container restart method name

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -52,7 +52,7 @@ def run(cmd: str, trigger: Union[List[str], str] = []) -> LiveUpdateStep:
   """
   pass
 
-def container_restart() -> LiveUpdateStep:
+def restart_container() -> LiveUpdateStep:
   """Specify that a container should be restarted when it is live-updated.
 
   May only be included in a `live_update` once, and only as the last step.

--- a/src/_data/api_functions.yaml
+++ b/src/_data/api_functions.yaml
@@ -1,7 +1,7 @@
 functions:
 - allow_k8s_contexts
 - blob
-- container_restart
+- restart_container
 - custom_build
 - decode_json
 - default_registry


### PR DESCRIPTION
I struggled a bit to figure out why my `container_restart` method wasn't working it turns out the API docs don't seem to match the code. 

https://docs.tilt.dev/api.html#api.restart_container . 

Hopefully this fixes that.