### PR TITLE
run make-api as local_resource to speed up tiltfile

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -6,11 +6,7 @@ enable_feature("snapshots")
 default_registry('gcr.io/windmill-public-containers')
 
 # Generate the API docs.
-read_file('deploy/api.dockerfile')
-read_file('api/api.py')
-local('make api')
-
-read_file('Makefile') # rebuild if we change the Makefile
+local_resource('make-api', 'make api', ['deploy/api.dockerfile', 'api/api.py', 'Makefile'])
 
 k8s_yaml('deploy/serve.yaml')
 


### PR DESCRIPTION
Hello @nicks, @jazzdan,

Please review the following commits I made in branch maiamcc/local-resource:

a43a03a77771ecbafe013611d9e259aef2a5e1d1 (2019-09-24 15:54:42 -0400)
run make-api as local_resource to speed up tiltfile

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics