### PR TITLE
docs: API ref for docker_prune_settings

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -633,3 +633,24 @@ def disable_snapshots() -> None:
     developer can always simply edit it out of the Tiltfile, but it at least
     ensures a pretty high bar of intent.
     """
+
+def docker_prune_settings(disable: bool=True, max_age_mins: int=360, num_builds: int=0, interval_hrs: int=1) -> None:
+  """
+  Configures Tilt's Docker Pruner, which runs occasionally in the background and prunes Docker images associated
+  with your current project.
+
+  The pruner runs soon after startup (as soon as at least some resources are declared, and there are no pending builds).
+  Subsequently, it runs after every ``num_builds`` Docker builds, or, if ``num_builds`` is not set, every ``interval_hrs`` hours.
+
+  The pruner will prune:
+    - stopped containers built by Tilt that are at least ``max_age_mins`` mins old
+    - images built by Tilt and associated with this Tilt run that are at least ``max_age_mins`` mins old
+    - dangling build caches that are at least ``max_age_mins`` mins old
+
+  Args:
+    disable: if true, disable the Docker Pruner
+    max_age_mins: maximum age, in minutes, of images/containers to retain. Defaults to 360 mins., i.e. 6 hours
+    num_builds: number of Docker builds after which to run a prune. (If unset, the pruner instead runs every ``interval_hrs`` hours)
+    interval_hrs: run a Docker Prune every ``interval_hrs`` hours (unless ``num_builds`` is set, in which case use the "prune every X builds" logic). Defaults to 1 hour
+  """
+  pass

--- a/src/_data/api_functions.yaml
+++ b/src/_data/api_functions.yaml
@@ -7,6 +7,7 @@ functions:
 - default_registry
 - disable_snapshots
 - docker_build
+- docker_prune_settings
 - enable_feature
 - fail
 - fall_back_on

--- a/src/_includes/functions.html
+++ b/src/_includes/functions.html
@@ -197,6 +197,39 @@ ensures a pretty high bar of intent.</p>
 </tbody>
 </table>
 </dd></dl><dl class="function">
+<dt id="api.docker_prune_settings">
+<code class="descclassname">api.</code><code class="descname">docker_prune_settings</code><span class="sig-paren">(</span><em>disable=True</em>, <em>max_age_mins=360</em>, <em>num_builds=0</em>, <em>interval_hrs=1</em><span class="sig-paren">)</span><a class="headerlink" href="#api.docker_prune_settings" title="Permalink to this definition">&#xB6;</a></dt>
+<dd><p>Configures Tilt&#x2019;s Docker Pruner, which runs occasionally in the background and prunes Docker images associated
+with your current project.</p>
+<p>The pruner runs soon after startup (as soon as at least some resources are declared, and there are no pending builds).
+Subsequently, it runs after every <code class="docutils literal notranslate"><span class="pre">num_builds</span></code> Docker builds, or, if <code class="docutils literal notranslate"><span class="pre">num_builds</span></code> is not set, every <code class="docutils literal notranslate"><span class="pre">interval_hrs</span></code> hours.</p>
+<dl class="docutils">
+<dt>The pruner will prune:</dt>
+<dd><ul class="first last simple">
+<li>stopped containers built by Tilt that are at least <code class="docutils literal notranslate"><span class="pre">max_age_mins</span></code> mins old</li>
+<li>images built by Tilt and associated with this Tilt run that are at least <code class="docutils literal notranslate"><span class="pre">max_age_mins</span></code> mins old</li>
+<li>dangling build caches that are at least <code class="docutils literal notranslate"><span class="pre">max_age_mins</span></code> mins old</li>
+</ul>
+</dd>
+</dl>
+<table class="docutils field-list" frame="void" rules="none">
+<col class="field-name">
+<col class="field-body">
+<tbody valign="top">
+<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
+<li><strong>disable</strong> (<code class="xref py py-class docutils literal notranslate"><span class="pre">bool</span></code>) &#x2013; if true, disable the Docker Pruner</li>
+<li><strong>max_age_mins</strong> (<code class="xref py py-class docutils literal notranslate"><span class="pre">int</span></code>) &#x2013; maximum age, in minutes, of images/containers to retain. Defaults to 360 mins., i.e. 6 hours</li>
+<li><strong>num_builds</strong> (<code class="xref py py-class docutils literal notranslate"><span class="pre">int</span></code>) &#x2013; number of Docker builds after which to run a prune. (If unset, the pruner instead runs every <code class="docutils literal notranslate"><span class="pre">interval_hrs</span></code> hours)</li>
+<li><strong>interval_hrs</strong> (<code class="xref py py-class docutils literal notranslate"><span class="pre">int</span></code>) &#x2013; run a Docker Prune every <code class="docutils literal notranslate"><span class="pre">interval_hrs</span></code> hours (unless <code class="docutils literal notranslate"><span class="pre">num_builds</span></code> is set, in which case use the &#x201C;prune every X builds&#x201D; logic). Defaults to 1 hour</li>
+</ul>
+</td>
+</tr>
+<tr class="field-even field"><th class="field-name">Return type:</th><td class="field-body"><p class="first last"><code class="docutils literal notranslate"><span class="pre">None</span></code></p>
+</td>
+</tr>
+</tbody>
+</table>
+</dd></dl><dl class="function">
 <dt id="api.enable_feature">
 <code class="descclassname">api.</code><code class="descname">enable_feature</code><span class="sig-paren">(</span><em>feature_name</em><span class="sig-paren">)</span><a class="headerlink" href="#api.enable_feature" title="Permalink to this definition">&#xB6;</a></dt>
 <dd><p>Configures Tilt to enable non-default features (e.g., experimental or deprecated).</p>


### PR DESCRIPTION
Hello @nicks, @jazzdan,

Please review the following commits I made in branch maiamcc/docker-prune:

d37bec0a6cc066ce9492fe39ca768f376f491fe5 (2019-10-15 13:54:17 -0400)
docs: API ref for docker_prune_settings

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics