### PR TITLE
docs: undocument resource_assembly_version

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -229,9 +229,6 @@ def k8s_resource(workload: str, new_name: str = "",
                  trigger_mode: TriggerMode = TRIGGER_MODE_AUTO, resource_deps: List[str] = []) -> None:
   """Configures a kubernetes resources
 
-  This description apply to `k8s_resource_assembly_version` 2.
-  If you are running Tilt version < 0.8.0 and/or do not call `k8s_resource_assembly_version(2)`, see :meth:`k8s_resource_v1_DEPRECATED` instead.
-
   Args:
     workload: which workload's resource to configure. This is a colon-separated
       string consisting of one or more of (name, kind, namespace, group), e.g.,
@@ -278,47 +275,6 @@ def dc_resource(name: str, trigger_mode: TriggerMode = TRIGGER_MODE_AUTO, resour
       See the `Resource Dependencies docs <resource_dependencies.html>`_.
   """
 
-  pass
-
-def k8s_resource_assembly_version(version: int) -> None:
-  """
-  Specifies which version of k8s resource assembly loading to use.
-
-  This function is deprecated and will be removed.
-  See `Resource Assembly Migration <resource_assembly_migration.html>`_ for information.
-
-  Changes the behavior of :meth:`k8s_resource`.
-  """
-
-def k8s_resource_v1_DEPRECATED(name: str, yaml: Union[str, Blob] = "", image: Union[str, FastBuild] = "",
-    port_forwards: Union[str, int, List[int]] = [], extra_pod_selectors: Union[Dict[str, str], List[Dict[str, str]]] = []) -> None:
-  """NOTE: This is actually named :meth:`k8s_resource`. This documents
-  the behavior of this method after a call to :meth:`k8s_resource_assembly_version` with value `1`.
-  This behavior is deprecated and will be removed.
-  See `Resource Assembly Migration <resource_assembly_migration.html>`_ for information.
-
-  Creates a kubernetes resource that tilt can deploy using the specified image.
-
-  Args:
-    name: What call this resource in the UI. If ``image`` is not specified ``name`` will be used as the image to group by.
-    yaml: Optional YAML. If this arg is not passed, we
-      expect to be able to extract it from an existing resource
-      (by looking for a k8s container running the specified ``image``).
-    image: An optional Image. If the image is not passed,
-      we expect to be able to extract it from an existing resource.
-    port_forwards: Local ports to connect to the pod. If no
-      target port is specified, will use the first container port.
-      Example values: 9000 (connect localhost:9000 to the default container port),
-      '9000:8000' (connect localhost:9000 to the container port 8000),
-      ['9000:8000', '9001:8001'] (connect localhost:9000 and :9001 to the
-      container ports 8000 and 8001, respectively).
-    extra_pod_selectors: In addition to relying on Tilt's heuristics to automatically
-      find K8S resources associated with this resource, a user may specify extra
-      labelsets to force entities to be associated with this resource. An entity
-      will be associated with this resource if it has all of the labels in at
-      least one of the entries specified (but still also if it meets any of
-      Tilt's usual mechanisms).
-  """
   pass
 
 def filter_yaml(yaml: Union[str, List[str], Blob], labels: dict=None, name: str=None, namespace: str=None, kind: str=None, api_version: str=None):
@@ -579,7 +535,6 @@ class K8sObjectID:
 
 def workload_to_resource_function(fn: Callable[[K8sObjectID], str]) -> None:
     """
-    (Only supported with :meth:`k8s_resource_assembly_version` >= 2(2))
     Provide a function that will be used to name `Tilt resources <tiltfile_concepts.html#resources>`_.
 
     Tilt will auto-generate resource names for you. If you do not like the names

--- a/src/_data/api_functions.yaml
+++ b/src/_data/api_functions.yaml
@@ -20,8 +20,6 @@ functions:
 - k8s_context
 - k8s_kind
 - k8s_resource
-- k8s_resource_assembly_version
-- k8s_resource_v1_DEPRECATED
 - k8s_yaml
 - kustomize
 - listdir

--- a/src/_includes/functions.html
+++ b/src/_includes/functions.html
@@ -477,8 +477,6 @@ This uses the k8s json path template syntax, described <a class="reference exter
 <dt id="api.k8s_resource">
 <code class="descclassname">api.</code><code class="descname">k8s_resource</code><span class="sig-paren">(</span><em>workload</em>, <em>new_name=&apos;&apos;</em>, <em>port_forwards=[]</em>, <em>extra_pod_selectors=[]</em>, <em>trigger_mode=TRIGGER_MODE_AUTO</em>, <em>resource_deps=[]</em><span class="sig-paren">)</span><a class="headerlink" href="#api.k8s_resource" title="Permalink to this definition">&#xB6;</a></dt>
 <dd><p>Configures a kubernetes resources</p>
-<p>This description apply to <cite>k8s_resource_assembly_version</cite> 2.
-If you are running Tilt version &lt; 0.8.0 and/or do not call <cite>k8s_resource_assembly_version(2)</cite>, see <a class="reference internal" href="#api.k8s_resource_v1_DEPRECATED" title="api.k8s_resource_v1_DEPRECATED"><code class="xref py py-meth docutils literal notranslate"><span class="pre">k8s_resource_v1_DEPRECATED()</span></code></a> instead.</p>
 <table class="docutils field-list" frame="void" rules="none">
 <col class="field-name">
 <col class="field-body">
@@ -518,60 +516,6 @@ Tilt&#x2019;s usual mechanisms).</li>
 <li><strong>resource_deps</strong> (<code class="xref py py-class docutils literal notranslate"><span class="pre">List</span></code>[<code class="xref py py-class docutils literal notranslate"><span class="pre">str</span></code>]) &#x2013; <p>a list of resources on which this resource depends.
 See the <a class="reference external" href="resource_dependencies.html">Resource Dependencies docs</a>.</p>
 </li>
-</ul>
-</td>
-</tr>
-<tr class="field-even field"><th class="field-name">Return type:</th><td class="field-body"><p class="first last"><code class="docutils literal notranslate"><span class="pre">None</span></code></p>
-</td>
-</tr>
-</tbody>
-</table>
-</dd></dl><dl class="function">
-<dt id="api.k8s_resource_assembly_version">
-<code class="descclassname">api.</code><code class="descname">k8s_resource_assembly_version</code><span class="sig-paren">(</span><em>version</em><span class="sig-paren">)</span><a class="headerlink" href="#api.k8s_resource_assembly_version" title="Permalink to this definition">&#xB6;</a></dt>
-<dd><p>Specifies which version of k8s resource assembly loading to use.</p>
-<p>This function is deprecated and will be removed.
-See <a class="reference external" href="resource_assembly_migration.html">Resource Assembly Migration</a> for information.</p>
-<p>Changes the behavior of <a class="reference internal" href="#api.k8s_resource" title="api.k8s_resource"><code class="xref py py-meth docutils literal notranslate"><span class="pre">k8s_resource()</span></code></a>.</p>
-<table class="docutils field-list" frame="void" rules="none">
-<col class="field-name">
-<col class="field-body">
-<tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Return type:</th><td class="field-body"><code class="docutils literal notranslate"><span class="pre">None</span></code></td>
-</tr>
-</tbody>
-</table>
-</dd></dl><dl class="function">
-<dt id="api.k8s_resource_v1_DEPRECATED">
-<code class="descclassname">api.</code><code class="descname">k8s_resource_v1_DEPRECATED</code><span class="sig-paren">(</span><em>name</em>, <em>yaml=&apos;&apos;</em>, <em>image=&apos;&apos;</em>, <em>port_forwards=[]</em>, <em>extra_pod_selectors=[]</em><span class="sig-paren">)</span><a class="headerlink" href="#api.k8s_resource_v1_DEPRECATED" title="Permalink to this definition">&#xB6;</a></dt>
-<dd><p>NOTE: This is actually named <a class="reference internal" href="#api.k8s_resource" title="api.k8s_resource"><code class="xref py py-meth docutils literal notranslate"><span class="pre">k8s_resource()</span></code></a>. This documents
-the behavior of this method after a call to <a class="reference internal" href="#api.k8s_resource_assembly_version" title="api.k8s_resource_assembly_version"><code class="xref py py-meth docutils literal notranslate"><span class="pre">k8s_resource_assembly_version()</span></code></a> with value <cite>1</cite>.
-This behavior is deprecated and will be removed.
-See <a class="reference external" href="resource_assembly_migration.html">Resource Assembly Migration</a> for information.</p>
-<p>Creates a kubernetes resource that tilt can deploy using the specified image.</p>
-<table class="docutils field-list" frame="void" rules="none">
-<col class="field-name">
-<col class="field-body">
-<tbody valign="top">
-<tr class="field-odd field"><th class="field-name">Parameters:</th><td class="field-body"><ul class="first simple">
-<li><strong>name</strong> (<code class="xref py py-class docutils literal notranslate"><span class="pre">str</span></code>) &#x2013; What call this resource in the UI. If <code class="docutils literal notranslate"><span class="pre">image</span></code> is not specified <code class="docutils literal notranslate"><span class="pre">name</span></code> will be used as the image to group by.</li>
-<li><strong>yaml</strong> (<code class="xref py py-data docutils literal notranslate"><span class="pre">Union</span></code>[<code class="xref py py-class docutils literal notranslate"><span class="pre">str</span></code>, <a class="reference internal" href="#api.Blob" title="api.Blob"><code class="xref py py-class docutils literal notranslate"><span class="pre">Blob</span></code></a>]) &#x2013; Optional YAML. If this arg is not passed, we
-expect to be able to extract it from an existing resource
-(by looking for a k8s container running the specified <code class="docutils literal notranslate"><span class="pre">image</span></code>).</li>
-<li><strong>image</strong> (<code class="xref py py-data docutils literal notranslate"><span class="pre">Union</span></code>[<code class="xref py py-class docutils literal notranslate"><span class="pre">str</span></code>, <a class="reference internal" href="#api.FastBuild" title="api.FastBuild"><code class="xref py py-class docutils literal notranslate"><span class="pre">FastBuild</span></code></a>]) &#x2013; An optional Image. If the image is not passed,
-we expect to be able to extract it from an existing resource.</li>
-<li><strong>port_forwards</strong> (<code class="xref py py-data docutils literal notranslate"><span class="pre">Union</span></code>[<code class="xref py py-class docutils literal notranslate"><span class="pre">str</span></code>, <code class="xref py py-class docutils literal notranslate"><span class="pre">int</span></code>, <code class="xref py py-class docutils literal notranslate"><span class="pre">List</span></code>[<code class="xref py py-class docutils literal notranslate"><span class="pre">int</span></code>]]) &#x2013; Local ports to connect to the pod. If no
-target port is specified, will use the first container port.
-Example values: 9000 (connect localhost:9000 to the default container port),
-&#x2018;9000:8000&#x2019; (connect localhost:9000 to the container port 8000),
-[&#x2018;9000:8000&#x2019;, &#x2018;9001:8001&#x2019;] (connect localhost:9000 and :9001 to the
-container ports 8000 and 8001, respectively).</li>
-<li><strong>extra_pod_selectors</strong> (<code class="xref py py-data docutils literal notranslate"><span class="pre">Union</span></code>[<code class="xref py py-class docutils literal notranslate"><span class="pre">Dict</span></code>[<code class="xref py py-class docutils literal notranslate"><span class="pre">str</span></code>, <code class="xref py py-class docutils literal notranslate"><span class="pre">str</span></code>], <code class="xref py py-class docutils literal notranslate"><span class="pre">List</span></code>[<code class="xref py py-class docutils literal notranslate"><span class="pre">Dict</span></code>[<code class="xref py py-class docutils literal notranslate"><span class="pre">str</span></code>, <code class="xref py py-class docutils literal notranslate"><span class="pre">str</span></code>]]]) &#x2013; In addition to relying on Tilt&#x2019;s heuristics to automatically
-find K8S resources associated with this resource, a user may specify extra
-labelsets to force entities to be associated with this resource. An entity
-will be associated with this resource if it has all of the labels in at
-least one of the entries specified (but still also if it meets any of
-Tilt&#x2019;s usual mechanisms).</li>
 </ul>
 </td>
 </tr>
@@ -848,8 +792,7 @@ Can be a file (in which case just that file will be synced) or directory (in whi
 </dd></dl><dl class="function">
 <dt id="api.workload_to_resource_function">
 <code class="descclassname">api.</code><code class="descname">workload_to_resource_function</code><span class="sig-paren">(</span><em>fn</em><span class="sig-paren">)</span><a class="headerlink" href="#api.workload_to_resource_function" title="Permalink to this definition">&#xB6;</a></dt>
-<dd><p>(Only supported with <a class="reference internal" href="#api.k8s_resource_assembly_version" title="api.k8s_resource_assembly_version"><code class="xref py py-meth docutils literal notranslate"><span class="pre">k8s_resource_assembly_version()</span></code></a> &gt;= 2(2))
-Provide a function that will be used to name <a class="reference external" href="tiltfile_concepts.html#resources">Tilt resources</a>.</p>
+<dd><p>Provide a function that will be used to name <a class="reference external" href="tiltfile_concepts.html#resources">Tilt resources</a>.</p>
 <p>Tilt will auto-generate resource names for you. If you do not like the names
 it generates, you can use this to customize how Tilt generates names.</p>
 <p>Example</p>


### PR DESCRIPTION
It's probably fine to get rid of the "k8s_resource_v1_DEPRECATED" eyesore at this point