### PR TITLE
docs: move telemetry info to its own guide, so we can link to it from the readme

### DIFF
--- a/docs/partner_program.md
+++ b/docs/partner_program.md
@@ -33,9 +33,9 @@ Analytics Settings
 - Repo: 3QLdKIWhsYTCsPI0vtsx6Q==
 ```
 
-All strings in analytics are hashed, to help protect your privacy and your code.
-We use the aggregate data so that both of us (our team and your dev-ops team) has
-an accurate picture of how your team is using Tilt and what parts of it are slow
+We use the aggregate data so that both of us (our team and your dev-ops team)
+has an accurate picture of how your team is using Tilt and what parts of it are
+slow. For more info, see ["What does Tilt send?"](telemetry_faq.html).
 
 If this sounds interesting to you, please email our CEO
 [Dan](mailto:dan@tilt.dev?subject=Tilt partner program) to get set up.

--- a/docs/telemetry_faq.md
+++ b/docs/telemetry_faq.md
@@ -1,0 +1,117 @@
+---
+title: What does Tilt send?
+layout: docs
+---
+
+Tilt nudges you to opt in or out of analytics.
+
+You can opt-in from the command-line with:
+
+```bash
+tilt analytics opt in
+```
+
+You can change your mind at any time by running:
+
+```bash
+tilt analytics opt out
+```
+
+and restarting Tilt.
+
+Until you make a choice, Tilt will send a minimal amount of data (this helps us improve the installation/opting flow).
+
+### Why does Tilt want analytics?
+
+We're a small company trying to make Tilt awesomer.
+
+We can do this better if we understand which features people are using and which bugs people are running into.
+
+### Where does the analytics data go?
+
+Tilt sends telemetry data to our in-house analytics ingestion server at `events.windmill.build`.
+
+This data may be stored in managed database services (like Google Cloud) or
+managed analytics services (like Datadog) to help us analyze it.
+
+We will not resell or give away this data to advertisers.
+
+### What kinds of data does Tilt record if I opt-in?
+
+We're interested in how people, in aggregate, use Tilt -- which Tiltfile
+built-ins people use, what parts of the Web UI people interact with, etc.
+
+We don't want to collect data about you or your project.
+
+When possible, strings that may contain information about your project (repo names, service
+names, directory names) are hashed to protect your privacy.
+
+The  hashing system isn't foolproof. It's possible that some of the data we collect
+could include snippets of data about your project (e.g. that you have a service
+named `deathray-backend` or an error message that includes the string it failed
+to parse). You should probably not opt-in if you're working on a classified
+project.
+
+### Can you give some examples?
+
+Here's an example of the data Tilt sends when you run `tilt up` with analytics enabled:
+
+```
+{
+  "watch": "true",
+  "version": "0.10.18-dev",
+  "user": "a62525469776f5b299733bdc95718d47",
+  "os": "linux",
+  "name": "tilt.cmd.up",
+  "mode": "auto",
+  "machine": "8c581ff2fc00c6a47ecbd50abe47fb40",
+  "git.origin": "3QLdKIWhsYTCsPI0vtsx6Q=="
+}
+```
+
+Here's an example of the data Tilt sends when a Tiltfile loads:
+
+```
+{
+  "version": "0.10.18-dev",
+  "user": "a62525469776f5b299733bdc95718d47",
+  "tiltfile.invoked.docker_build.arg.ref": "3",
+  "tiltfile.invoked.docker_build.arg.live_update": "3",
+  "tiltfile.invoked.docker_build.arg.ignore": "3",
+  "tiltfile.invoked.docker_build.arg.dockerfile": "3",
+  "tiltfile.invoked.docker_build.arg.context": "3",
+  "tiltfile.invoked.docker_build": "3",
+  "tiltfile.invoked.default_registry.arg.name": "1",
+  "tiltfile.invoked.default_registry": "1",
+  "os": "linux",
+  "name": "tilt.tiltfile.loaded",
+  "machine": "8c581ff2fc00c6a47ecbd50abe47fb40",
+  "git.origin": "3QLdKIWhsYTCsPI0vtsx6Q=="
+}
+```
+
+We've talked about adding a command that displays everything Tilt is sending in
+a part of the web UI, for transparency. If you're interested in this, let us
+know.
+
+### What other ways can I control analytics?
+
+You can disable analytics in the current environment by running:
+
+```bash
+export TILT_DISABLE_ANALYTICS="true"
+```
+
+You can also enable analytics in the Tiltfile by adding:
+
+```python
+analytics_settings(enable=True)
+```
+
+The Tiltfile setting overrides user preferences. It's intended for
+devtools teams opting-in all users on the team.
+
+The environment setting overrides both the Tiltfile and user preferences.
+
+
+

--- a/src/_data/docs.yml
+++ b/src/_data/docs.yml
@@ -56,6 +56,8 @@
   items:
   - title: Who is Tilt for?
     href: product_faq.html
+  - title: What does Tilt send?
+    href: telemetry_faq.html
   - title: Frequently Asked Questions
     href: faq.html
   - title: Tiltfile API Reference


### PR DESCRIPTION
Hello @dbentley, @jazzdan,

Please review the following commits I made in branch nicks/telemetry:

7101eb782d896c6f826f2fcd54622acf75fb6b6d (2019-11-14 20:48:25 -0500)
docs: move telemetry info to its own guide, so we can link to it from the readme