### PR TITLE
homebrew: no need to brew tap, brew windmilleng/tap/tilt is enough

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -90,7 +90,6 @@ The installer first checks if you can install Tilt with Homebrew. If you'd prefe
 to run Homebrew manually, run:
 
 ```bash
-brew tap windmilleng/tap
 brew install windmilleng/tap/tilt
 ```
 


### PR DESCRIPTION
Just a small improvement: users of Homebrew do not need to care about the `brew tap` step since `brew install windmilleng/tap/tilt` will implicitely run `brew tap` if the tap has not already been cloned.

Just want to say: awesome project! 🤩