### PR TITLE
api/docs: update tiltfile concepts with new understanding of resource, clarify k8s_resource api docs

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -223,11 +223,28 @@ def trigger_mode(trigger_mode: TriggerMode):
 TRIGGER_MODE_AUTO = type('_sentinel', (TriggerMode,),
                  {'__repr__': lambda self: 'TRIGGER_MODE_AUTO'})()
 
+def dc_resource(name: str, trigger_mode: TriggerMode = TRIGGER_MODE_AUTO, resource_deps: List[str] = []) -> None:
+  """Configures the Docker Compose resource of the given name. Note: Tilt does an amount of resource configuration
+  for you(for more info, see `Tiltfile Concepts: Resources <tiltfile_concepts.html#resources>`_); you only need
+  to invoke this function if you want to configure your resource beyond what Tilt does automatically.
+
+  Args:
+    trigger_mode: one of ``TRIGGER_MODE_AUTO`` or ``TRIGGER_MODE_MANUAL``. For more info, see the
+      `Manual Update Control docs <manual_update_control.html>`_.
+    resource_deps: a list of resources on which this resource depends.
+      See the `Resource Dependencies docs <resource_dependencies.html>`_.
+  """
+
+  pass
+
 def k8s_resource(workload: str, new_name: str = "",
                  port_forwards: Union[str, int, List[int]] = [],
                  extra_pod_selectors: Union[Dict[str, str], List[Dict[str, str]]] = [],
                  trigger_mode: TriggerMode = TRIGGER_MODE_AUTO, resource_deps: List[str] = []) -> None:
-  """Configures a kubernetes resources
+  """Configures the Kubernetes resource of the given name. Tilt assembles Kubernetes resources
+  automatically, as described in `Tiltfile Concepts: Resources <tiltfile_concepts.html#resources>`_).
+  Calling ``k8s_resource`` is *optional*; you can use this function to configure port forwarding for
+  your resource, to rename it, or to adjust any of the other settings specified below.
 
   Args:
     workload: which workload's resource to configure. This is a colon-separated
@@ -263,18 +280,6 @@ def k8s_resource(workload: str, new_name: str = "",
     resource_deps: a list of resources on which this resource depends.
       See the `Resource Dependencies docs <resource_dependencies.html>`_.
   """
-  pass
-
-def dc_resource(name: str, trigger_mode: TriggerMode = TRIGGER_MODE_AUTO, resource_deps: List[str] = []) -> None:
-  """Configures the Docker Compose resource of the given name.
-
-  Args:
-    trigger_mode: one of ``TRIGGER_MODE_AUTO`` or ``TRIGGER_MODE_MANUAL``. For more info, see the
-      `Manual Update Control docs <manual_update_control.html>`_.
-    resource_deps: a list of resources on which this resource depends.
-      See the `Resource Dependencies docs <resource_dependencies.html>`_.
-  """
-
   pass
 
 def filter_yaml(yaml: Union[str, List[str], Blob], labels: dict=None, name: str=None, namespace: str=None, kind: str=None, api_version: str=None):

--- a/docs/tiltfile_concepts.md
+++ b/docs/tiltfile_concepts.md
@@ -127,17 +127,34 @@ docker_build("companyname/frontend", "frontend", build_args={"target": "local"})
 
 You can combine multiple optional arguments.
 
-## Workloads
+## Kubernetes Workloads
 
 A workload is roughly a Kubernetes object that has a container. This means it's running an
 image and might produce logs and have some kind of status.
 
 ## Resources
-Tilt's UI makes it easier to find errors by grouping related status and output. E.g., when you edit a file, you want to know what error it caused, whether it's an error at build-time, deploy-time, or run-time. Tilt calls these groupings "Resources". Each Resource has a line in the UI that can be expanded and investigated.
+A "resource" is a bundle of work managed by Tilt: e.g. a Docker image to build + Kubernetes
+YAML to apply, or a command to run locally (i.e. a [local resource](local_resource.html)).
+Tilt groups disparate bits of work (e.g. `docker build && kubectl apply`) into resources to
+unify status and output, and make it easier to find errors: for instance, when something
+goes wrong after you edit a file, you want to know what error it caused, whether it's an
+error at build-time, deploy-time, or run-time. Each resource has a line in the UI that
+can be expanded and investigated.
 
-Tilt generates these groups after executing your `Tiltfile`. It does this by scanning all loaded yaml for any k8s objects that it considers a workload. Each of these workloads becomes a Tilt resource.
+Tilt generates these bundles of work after executing your `Tiltfile`. Some Tiltfile calls
+(e.g. `local_resource`) correspond to a single resource; for other calls (e.g. `docker_build`
++ `k8s_yaml`), Tilt must join multiple bits of work into a single resource. For Kubernetes
+resources, Tilt does this assembly by scanning all loaded YAML for any k8s objects that it
+considers a workload. Each of these workloads becomes a Tilt resource. If Tilt finds any image
+build directives corresponding to an image in a workload, that directive also gets added to
+that resource. (The assembly logic is similar for Docker Compose resources. For more
+information, see the [Docker Compose documentation](docker_compose.html).)
 
-You can configure a resource with a call to [`k8s_resource`](api.html#api.k8s_resource). Today there are two relevant configuration arguments: `new_name` and `port_forwards`.
+In many cases, Tilt's automatically resource assembly logic will be suffient for you to run
+your app. However, if you need to configure your Kubernetes resources on top of Tilt's
+automatic assembly, you can do so with a call to [`k8s_resource`](api.html#api.k8s_resource).
+Here we'll discuss the most common configuration arguments: `new_name` and `port_forwards`.
+For discussion of other available arguments, see the [api spec](api.html#api.k8s_resource).
 
 `new_name` allows you to specify a new resource name, in case you do not like the automatically generated one.
 

--- a/src/_includes/functions.html
+++ b/src/_includes/functions.html
@@ -110,7 +110,9 @@ then re-tag it with its own tag before pushing to your cluster. See <a class="re
 </dd></dl><dl class="function">
 <dt id="api.dc_resource">
 <code class="descclassname">api.</code><code class="descname">dc_resource</code><span class="sig-paren">(</span><em>name</em>, <em>trigger_mode=TRIGGER_MODE_AUTO</em>, <em>resource_deps=[]</em><span class="sig-paren">)</span><a class="headerlink" href="#api.dc_resource" title="Permalink to this definition">&#xB6;</a></dt>
-<dd><p>Configures the Docker Compose resource of the given name.</p>
+<dd><p>Configures the Docker Compose resource of the given name. Note: Tilt does an amount of resource configuration
+for you(for more info, see <a class="reference external" href="tiltfile_concepts.html#resources">Tiltfile Concepts: Resources</a>); you only need
+to invoke this function if you want to configure your resource beyond what Tilt does automatically.</p>
 <table class="docutils field-list" frame="void" rules="none">
 <col class="field-name">
 <col class="field-body">
@@ -476,7 +478,10 @@ This uses the k8s json path template syntax, described <a class="reference exter
 </dd></dl><dl class="function">
 <dt id="api.k8s_resource">
 <code class="descclassname">api.</code><code class="descname">k8s_resource</code><span class="sig-paren">(</span><em>workload</em>, <em>new_name=&apos;&apos;</em>, <em>port_forwards=[]</em>, <em>extra_pod_selectors=[]</em>, <em>trigger_mode=TRIGGER_MODE_AUTO</em>, <em>resource_deps=[]</em><span class="sig-paren">)</span><a class="headerlink" href="#api.k8s_resource" title="Permalink to this definition">&#xB6;</a></dt>
-<dd><p>Configures a kubernetes resources</p>
+<dd><p>Configures the Kubernetes resource of the given name. Tilt assembles Kubernetes resources
+automatically, as described in <a class="reference external" href="tiltfile_concepts.html#resources">Tiltfile Concepts: Resources</a>).
+Calling <code class="docutils literal notranslate"><span class="pre">k8s_resource</span></code> is <em>optional</em>; you can use this function to configure port forwarding for
+your resource, to rename it, or to adjust any of the other settings specified below.</p>
 <table class="docutils field-list" frame="void" rules="none">
 <col class="field-name">
 <col class="field-body">


### PR DESCRIPTION
Matt Hodgekins at Datadog got tripped up b/c he didn't realize Tilt
automatically did most of the k8s resource config for you, asked us
to clarify our docs around this. While I was in here, I updated
Tiltfile Concepts: Resources to be more in line with our new definition
of "resource" (i.e. one that includes both K8s resources and local resources)