### PR TITLE
update: bump default version to v0.10.26

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -100,14 +100,14 @@ If you'd prefer to download the binary manually:
 On MacOS:
 
 ```bash
-curl -fsSL https://github.com/windmilleng/tilt/releases/download/v0.10.25/tilt.0.10.25.mac.x86_64.tar.gz | tar -xzv tilt && \
+curl -fsSL https://github.com/windmilleng/tilt/releases/download/v0.10.26/tilt.0.10.26.mac.x86_64.tar.gz | tar -xzv tilt && \
   sudo mv tilt /usr/local/bin/tilt
 ```
 
 On Linux:
 
 ```bash
-curl -fsSL https://github.com/windmilleng/tilt/releases/download/v0.10.25/tilt.0.10.25.linux.x86_64.tar.gz | tar -xzv tilt && \
+curl -fsSL https://github.com/windmilleng/tilt/releases/download/v0.10.26/tilt.0.10.26.linux.x86_64.tar.gz | tar -xzv tilt && \
   sudo mv tilt /usr/local/bin/tilt
 ```
 

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -18,7 +18,7 @@ $ brew install windmilleng/tap/tilt
 ### Option B) Installing Tilt from release binaries
 
 ```bash
-curl -L https://github.com/windmilleng/tilt/releases/download/v0.10.25/tilt.0.10.25.mac.x86_64.tar.gz | tar -xzv tilt && \
+curl -L https://github.com/windmilleng/tilt/releases/download/v0.10.26/tilt.0.10.26.mac.x86_64.tar.gz | tar -xzv tilt && \
   sudo mv tilt /usr/local/bin/tilt
 ```
 
@@ -26,7 +26,7 @@ On Linux
 --------
 
 ```bash
-curl -L https://github.com/windmilleng/tilt/releases/download/v0.10.25/tilt.0.10.25.linux.x86_64.tar.gz | tar -xzv tilt && \
+curl -L https://github.com/windmilleng/tilt/releases/download/v0.10.26/tilt.0.10.26.linux.x86_64.tar.gz | tar -xzv tilt && \
     sudo mv tilt /usr/local/bin/tilt
 ```
 


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/bump:

bf8fea4c79bf4d74680dfc4f21a1ec121ea24aae (2020-01-06 17:19:48 -0500)
update: bump default version to v0.10.26