### PR TITLE
tilt.build: use buildkit when building api image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 api:
 	docker rm tilt.api || exit 0
 	rm -fR api/api.html
-	docker build -t tilt.api -f deploy/api.dockerfile .
+	DOCKER_BUILDKIT=1 docker build -t tilt.api -f deploy/api.dockerfile .
 	docker run --name tilt.api tilt.api
 	docker cp tilt.api:/src/functions.yaml src/_data/api_functions.yaml
 	docker cp tilt.api:/src/functions.html src/_includes/functions.html


### PR DESCRIPTION
Without buildkit, a fully cached build takes 15-30 seconds, mostly spent transferring the build context to the docker daemon.

I haven't looked into how, but apparently buildkit somehow optimizes that away, so a build only takes 1-3 seconds.