### PR TITLE
api: add docker_build(ssh='default') to api docs

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -71,7 +71,7 @@ def restart_container() -> LiveUpdateStep:
   """
   pass
 
-def docker_build(ref: str, context: str, build_args: Dict[str, str] = {}, dockerfile: str = "Dockerfile", dockerfile_contents: Union[str, Blob] = "", live_update: List[LiveUpdateStep]=[], match_in_env_vars: bool = False, ignore: Union[str, List[str]] = [], only: Union[str, List[str]] = [], entrypoint: str = "", target: str = "") -> None:
+def docker_build(ref: str, context: str, build_args: Dict[str, str] = {}, dockerfile: str = "Dockerfile", dockerfile_contents: Union[str, Blob] = "", live_update: List[LiveUpdateStep]=[], match_in_env_vars: bool = False, ignore: Union[str, List[str]] = [], only: Union[str, List[str]] = [], entrypoint: str = "", target: str = "", ssh: Union[str, List[str]] = "") -> None:
   """Builds a docker image.
 
   Note that you can't set both the `dockerfile` and `dockerfile_contents` arguments (will throw an error).
@@ -94,6 +94,7 @@ def docker_build(ref: str, context: str, build_args: Dict[str, str] = {}, docker
     only: set of file paths that should be considered for the build. All other changes will not trigger a build and will not be included in images. Inverse of ignore parameter. Only accepts real paths, not file globs.
     entrypoint: command to run when this container starts. Takes precedence over the container's ``CMD`` or ``ENTRYPOINT``, and over a `container command specified in k8s YAML <https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/>`_. Will be evaluated in a shell context: e.g. ``entrypoint="foo.sh bar"`` will be executed in the container as ``/bin/sh -c 'foo.sh bar'``.
     target: Specify a build stage in the Dockerfile. Equivalent to the ``docker build --target`` flag.
+    ssh: Include SSH secrets in your build. Use ssh='default' to clone private repositories inside a Dockerfile. Uses the syntax in the `Docker build --ssh flag <https://docs.docker.com/develop/develop-images/build_enhancements/#using-ssh-to-access-private-data-in-builds>`_.
   """
   pass
 

--- a/src/_includes/functions.html
+++ b/src/_includes/functions.html
@@ -1095,6 +1095,10 @@ ensures a pretty high bar of intent.
            <em>
             target=&apos;&apos;
            </em>
+           ,
+           <em>
+            ssh=&apos;&apos;
+           </em>
            <span class="sig-paren">
             )
            </span>
@@ -1466,6 +1470,40 @@ ensures a pretty high bar of intent.
                   </span>
                  </code>
                  flag.
+                </li>
+                <li>
+                 <strong>
+                  ssh
+                 </strong>
+                 (
+                 <code class="xref py py-data docutils literal notranslate">
+                  <span class="pre">
+                   Union
+                  </span>
+                 </code>
+                 [
+                 <code class="xref py py-class docutils literal notranslate">
+                  <span class="pre">
+                   str
+                  </span>
+                 </code>
+                 ,
+                 <code class="xref py py-class docutils literal notranslate">
+                  <span class="pre">
+                   List
+                  </span>
+                 </code>
+                 [
+                 <code class="xref py py-class docutils literal notranslate">
+                  <span class="pre">
+                   str
+                  </span>
+                 </code>
+                 ]]) &#x2013; Include SSH secrets in your build. Use ssh=&#x2019;default&#x2019; to clone private repositories inside a Dockerfile. Uses the syntax in the
+                 <a class="reference external" href="https://docs.docker.com/develop/develop-images/build_enhancements/#using-ssh-to-access-private-data-in-builds">
+                  Docker build &#x2013;ssh flag
+                 </a>
+                 .
                 </li>
                </ul>
               </td>


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/ssh2:

d0fea62d1e193c4e1212c7ee1f71764e761b5ae9 (2020-01-13 16:14:17 -0500)
api: add docker_build(ssh='default') to api docs