### PR TITLE
tiltfile: all jekyll services should block on the 'make api' job

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -37,6 +37,6 @@ docker_build('blog-site', '.', dockerfile='deploy/blog.dockerfile',
                                               'blog/Gemfile', 'blog/Gemfile.lock'])
              ])
 
-k8s_resource('tilt-site', port_forwards=4000)
+k8s_resource('tilt-site', port_forwards=4000, resource_deps=['make-api'])
 k8s_resource('docs-site', port_forwards=4001, resource_deps=['make-api'])
-k8s_resource('blog-site', port_forwards=4002)
+k8s_resource('blog-site', port_forwards=4002, resource_deps=['make-api'])


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/deps:

be2728f7049b669a0a2835c0db340dc1151487dd (2020-01-24 16:08:36 -0500)
tiltfile: all jekyll services should block on the 'make api' job
it produces files that they consume

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics