### PR TITLE
api: add documentation on docker_build(network=...)

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -71,7 +71,7 @@ def restart_container() -> LiveUpdateStep:
   """
   pass
 
-def docker_build(ref: str, context: str, build_args: Dict[str, str] = {}, dockerfile: str = "Dockerfile", dockerfile_contents: Union[str, Blob] = "", live_update: List[LiveUpdateStep]=[], match_in_env_vars: bool = False, ignore: Union[str, List[str]] = [], only: Union[str, List[str]] = [], entrypoint: str = "", target: str = "", ssh: Union[str, List[str]] = "") -> None:
+def docker_build(ref: str, context: str, build_args: Dict[str, str] = {}, dockerfile: str = "Dockerfile", dockerfile_contents: Union[str, Blob] = "", live_update: List[LiveUpdateStep]=[], match_in_env_vars: bool = False, ignore: Union[str, List[str]] = [], only: Union[str, List[str]] = [], entrypoint: str = "", target: str = "", ssh: Union[str, List[str]] = "", network: str = "") -> None:
   """Builds a docker image.
 
   Note that you can't set both the `dockerfile` and `dockerfile_contents` arguments (will throw an error).
@@ -95,6 +95,7 @@ def docker_build(ref: str, context: str, build_args: Dict[str, str] = {}, docker
     entrypoint: command to run when this container starts. Takes precedence over the container's ``CMD`` or ``ENTRYPOINT``, and over a `container command specified in k8s YAML <https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/>`_. Will be evaluated in a shell context: e.g. ``entrypoint="foo.sh bar"`` will be executed in the container as ``/bin/sh -c 'foo.sh bar'``.
     target: Specify a build stage in the Dockerfile. Equivalent to the ``docker build --target`` flag.
     ssh: Include SSH secrets in your build. Use ssh='default' to clone private repositories inside a Dockerfile. Uses the syntax in the `Docker build --ssh flag <https://docs.docker.com/develop/develop-images/build_enhancements/#using-ssh-to-access-private-data-in-builds>`_.
+    network: Set the networking mode for RUN instructions. Equivalent to the ``docker build --network`` flag.
   """
   pass
 

--- a/src/_includes/functions.html
+++ b/src/_includes/functions.html
@@ -1099,6 +1099,10 @@ ensures a pretty high bar of intent.
            <em>
             ssh=&apos;&apos;
            </em>
+           ,
+           <em>
+            network=&apos;&apos;
+           </em>
            <span class="sig-paren">
             )
            </span>
@@ -1504,6 +1508,30 @@ ensures a pretty high bar of intent.
                   Docker build &#x2013;ssh flag
                  </a>
                  .
+                </li>
+                <li>
+                 <strong>
+                  network
+                 </strong>
+                 (
+                 <code class="xref py py-class docutils literal notranslate">
+                  <span class="pre">
+                   str
+                  </span>
+                 </code>
+                 ) &#x2013; Set the networking mode for RUN instructions. Equivalent to the
+                 <code class="docutils literal notranslate">
+                  <span class="pre">
+                   docker
+                  </span>
+                  <span class="pre">
+                   build
+                  </span>
+                  <span class="pre">
+                   --network
+                  </span>
+                 </code>
+                 flag.
                 </li>
                </ul>
               </td>


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch nicks/network:

3e423b4c500f3fa5153e697e2af463bd1db2e9d8 (2020-01-27 16:50:45 -0500)
api: add documentation on docker_build(network=...)

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics