### PR TITLE
Fix quit command in getting started

### DIFF
--- a/docs/example_projects.md
+++ b/docs/example_projects.md
@@ -40,7 +40,7 @@ You should see the text `🍄 One-Up! 🍄`.
 
 Congratulations! You've run your first server with `tilt`.
 
-Type `q` to quit the status box. When you're finished, run
+Type `ctrl-C` to quit the status box. When you're finished, run
 
 ```
 tilt down


### PR DESCRIPTION
Looks like the doc may be out of date: 

<img width="835" alt="Screen Shot 2020-02-06 at 10 12 25 PM" src="https://user-images.githubusercontent.com/2553171/74005472-ce329980-492d-11ea-8578-9239d892c2a3.png">
