### PR TITLE
api docs: add read/decode/encode_yaml_stream

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -449,11 +449,7 @@ def read_json(path: str, default: str = None) -> StructuredDataType:
     default: If not `None` and the file at `path` does not exist, this value will be returned."""
   pass
 
-def decode_yaml(yaml: str) -> StructuredDataType:
-  """Deserializes a given string from YAML to Starlark. Fails if the string can't be parsed as YAML."""
-  pass
-
-def read_yaml(path: str, default: str = None) -> StructuredDataType:
+def read_yaml(path: str, default: StructuredDataType = None) -> StructuredDataType:
   """
   Reads the file at `path` and deserializes its contents into a starlark object
 
@@ -465,9 +461,32 @@ def read_yaml(path: str, default: str = None) -> StructuredDataType:
     default: If not `None` and the file at `path` does not exist, this value will be returned."""
   pass
 
+def read_yaml_stream(path: str, default: List[StructuredDataType] = None) -> List[StructuredDataType]:
+  """
+  Reads a yaml stream (i.e., yaml documents separated by ``"\\n---\\n"``) from the
+  file at `path` and deserializes its contents into a starlark object
+
+  If the `path` does not exist and `default` is not `None`, `default` will be returned.
+  In any other case, an error reading `path` will be a Tiltfile load error.
+
+  Args:
+    path: Path to the file locally (absolute, or relative to the location of the Tiltfile).
+    default: If not `None` and the file at `path` does not exist, this value will be returned."""
+  pass
+
 def decode_yaml(yaml: Union[str, Blob]) -> StructuredDataType:
   """
-  Deserializes the given yaml into a starlark object
+  Deserializes the given yaml document into a starlark object
+
+  Args:
+    yaml: the yaml to deserialize
+  """
+  pass
+
+def decode_yaml_stream(yaml: Union[str, Blob]) -> List[StructuredDataType]:
+  """
+  Deserializes the given yaml stream (i.e., any number of yaml
+  documents, separated by ``"\\n---\\n"``) into a list of starlark objects.
 
   Args:
     yaml: the yaml to deserialize
@@ -482,6 +501,18 @@ def encode_yaml(obj: StructuredDataType) -> Blob:
 
   Args:
     obj: the object to serialize
+  """
+  pass
+
+def encode_yaml_stream(objs: List[StructuredDataType]) -> Blob:
+  """
+  Serializes the given starlark objects into a YAML stream (i.e.,
+  multiple YAML documents, separated by ``"\\n---\\n"``).
+
+  Only supports maps with string keys, lists, strings, ints, and bools.
+
+  Args:
+    objs: the object to serialize
   """
   pass
 

--- a/src/_data/api_functions.yaml
+++ b/src/_data/api_functions.yaml
@@ -6,6 +6,7 @@ functions:
 - dc_resource
 - decode_json
 - decode_yaml
+- decode_yaml_stream
 - default_registry
 - disable_snapshots
 - docker_build
@@ -14,6 +15,7 @@ functions:
 - enable_feature
 - encode_json
 - encode_yaml
+- encode_yaml_stream
 - fail
 - fall_back_on
 - filter_yaml
@@ -31,6 +33,7 @@ functions:
 - read_file
 - read_json
 - read_yaml
+- read_yaml_stream
 - restart_container
 - run
 - struct

--- a/src/_includes/functions.html
+++ b/src/_includes/functions.html
@@ -859,7 +859,7 @@ See the
           </dt>
           <dd>
            <p>
-            Deserializes the given yaml into a starlark object
+            Deserializes the given yaml document into a starlark object
            </p>
            <table class="docutils field-list" frame="void" rules="none">
             <col class="field-name">
@@ -937,6 +937,124 @@ See the
                 </span>
                </code>
                ]]
+              </td>
+             </tr>
+            </tbody>
+           </table>
+          </dd>
+         </dl><dl class="function">
+          <dt id="api.decode_yaml_stream">
+           <code class="descclassname">
+           </code>
+           <code class="descname">
+            decode_yaml_stream
+           </code>
+           <span class="sig-paren">
+            (
+           </span>
+           <em>
+            yaml
+           </em>
+           <span class="sig-paren">
+            )
+           </span>
+           <a class="headerlink" href="#api.decode_yaml_stream" title="Permalink to this definition">
+            &#xB6;
+           </a>
+          </dt>
+          <dd>
+           <p>
+            Deserializes the given yaml stream (i.e., any number of yaml
+documents, separated by
+            <code class="docutils literal notranslate">
+             <span class="pre">
+              &quot;\n---\n&quot;
+             </span>
+            </code>
+            ) into a list of starlark objects.
+           </p>
+           <table class="docutils field-list" frame="void" rules="none">
+            <col class="field-name">
+            <col class="field-body">
+            <tbody valign="top">
+             <tr class="field-odd field">
+              <th class="field-name">
+               Parameters:
+              </th>
+              <td class="field-body">
+               <strong>
+                yaml
+               </strong>
+               (
+               <code class="xref py py-data docutils literal notranslate">
+                <span class="pre">
+                 Union
+                </span>
+               </code>
+               [
+               <code class="xref py py-class docutils literal notranslate">
+                <span class="pre">
+                 str
+                </span>
+               </code>
+               ,
+               <a class="reference internal" href="#api.Blob" title="api.Blob">
+                <code class="xref py py-class docutils literal notranslate">
+                 <span class="pre">
+                  Blob
+                 </span>
+                </code>
+               </a>
+               ]) &#x2013; the yaml to deserialize
+              </td>
+             </tr>
+             <tr class="field-even field">
+              <th class="field-name">
+               Return type:
+              </th>
+              <td class="field-body">
+               <code class="xref py py-class docutils literal notranslate">
+                <span class="pre">
+                 List
+                </span>
+               </code>
+               [
+               <code class="xref py py-data docutils literal notranslate">
+                <span class="pre">
+                 Union
+                </span>
+               </code>
+               [
+               <code class="xref py py-class docutils literal notranslate">
+                <span class="pre">
+                 Dict
+                </span>
+               </code>
+               [
+               <code class="xref py py-class docutils literal notranslate">
+                <span class="pre">
+                 str
+                </span>
+               </code>
+               ,
+               <code class="xref py py-data docutils literal notranslate">
+                <span class="pre">
+                 Any
+                </span>
+               </code>
+               ],
+               <code class="xref py py-class docutils literal notranslate">
+                <span class="pre">
+                 List
+                </span>
+               </code>
+               [
+               <code class="xref py py-data docutils literal notranslate">
+                <span class="pre">
+                 Any
+                </span>
+               </code>
+               ]]]
               </td>
              </tr>
             </tbody>
@@ -2332,6 +2450,114 @@ who added it to the Tiltfile what it&#x2019;s doing there.
                 </span>
                </code>
                ]]) &#x2013; the object to serialize
+              </td>
+             </tr>
+             <tr class="field-even field">
+              <th class="field-name">
+               Return type:
+              </th>
+              <td class="field-body">
+               <a class="reference internal" href="#api.Blob" title="api.Blob">
+                <code class="xref py py-class docutils literal notranslate">
+                 <span class="pre">
+                  Blob
+                 </span>
+                </code>
+               </a>
+              </td>
+             </tr>
+            </tbody>
+           </table>
+          </dd>
+         </dl><dl class="function">
+          <dt id="api.encode_yaml_stream">
+           <code class="descclassname">
+           </code>
+           <code class="descname">
+            encode_yaml_stream
+           </code>
+           <span class="sig-paren">
+            (
+           </span>
+           <em>
+            objs
+           </em>
+           <span class="sig-paren">
+            )
+           </span>
+           <a class="headerlink" href="#api.encode_yaml_stream" title="Permalink to this definition">
+            &#xB6;
+           </a>
+          </dt>
+          <dd>
+           <p>
+            Serializes the given starlark objects into a YAML stream (i.e.,
+multiple YAML documents, separated by
+            <code class="docutils literal notranslate">
+             <span class="pre">
+              &quot;\n---\n&quot;
+             </span>
+            </code>
+            ).
+           </p>
+           <p>
+            Only supports maps with string keys, lists, strings, ints, and bools.
+           </p>
+           <table class="docutils field-list" frame="void" rules="none">
+            <col class="field-name">
+            <col class="field-body">
+            <tbody valign="top">
+             <tr class="field-odd field">
+              <th class="field-name">
+               Parameters:
+              </th>
+              <td class="field-body">
+               <strong>
+                objs
+               </strong>
+               (
+               <code class="xref py py-class docutils literal notranslate">
+                <span class="pre">
+                 List
+                </span>
+               </code>
+               [
+               <code class="xref py py-data docutils literal notranslate">
+                <span class="pre">
+                 Union
+                </span>
+               </code>
+               [
+               <code class="xref py py-class docutils literal notranslate">
+                <span class="pre">
+                 Dict
+                </span>
+               </code>
+               [
+               <code class="xref py py-class docutils literal notranslate">
+                <span class="pre">
+                 str
+                </span>
+               </code>
+               ,
+               <code class="xref py py-data docutils literal notranslate">
+                <span class="pre">
+                 Any
+                </span>
+               </code>
+               ],
+               <code class="xref py py-class docutils literal notranslate">
+                <span class="pre">
+                 List
+                </span>
+               </code>
+               [
+               <code class="xref py py-data docutils literal notranslate">
+                <span class="pre">
+                 Any
+                </span>
+               </code>
+               ]]]) &#x2013; the object to serialize
               </td>
              </tr>
              <tr class="field-even field">
@@ -4751,13 +4977,43 @@ In any other case, an error reading
                  (
                  <code class="xref py py-data docutils literal notranslate">
                   <span class="pre">
-                   Optional
+                   Union
+                  </span>
+                 </code>
+                 [
+                 <code class="xref py py-class docutils literal notranslate">
+                  <span class="pre">
+                   Dict
                   </span>
                  </code>
                  [
                  <code class="xref py py-class docutils literal notranslate">
                   <span class="pre">
                    str
+                  </span>
+                 </code>
+                 ,
+                 <code class="xref py py-data docutils literal notranslate">
+                  <span class="pre">
+                   Any
+                  </span>
+                 </code>
+                 ],
+                 <code class="xref py py-class docutils literal notranslate">
+                  <span class="pre">
+                   List
+                  </span>
+                 </code>
+                 [
+                 <code class="xref py py-data docutils literal notranslate">
+                  <span class="pre">
+                   Any
+                  </span>
+                 </code>
+                 ],
+                 <code class="docutils literal notranslate">
+                  <span class="pre">
+                   None
                   </span>
                  </code>
                  ]) &#x2013; If not
@@ -4815,6 +5071,210 @@ In any other case, an error reading
                  </span>
                 </code>
                 ]]
+               </p>
+              </td>
+             </tr>
+            </tbody>
+           </table>
+          </dd>
+         </dl><dl class="function">
+          <dt id="api.read_yaml_stream">
+           <code class="descclassname">
+           </code>
+           <code class="descname">
+            read_yaml_stream
+           </code>
+           <span class="sig-paren">
+            (
+           </span>
+           <em>
+            path
+           </em>
+           ,
+           <em>
+            default=None
+           </em>
+           <span class="sig-paren">
+            )
+           </span>
+           <a class="headerlink" href="#api.read_yaml_stream" title="Permalink to this definition">
+            &#xB6;
+           </a>
+          </dt>
+          <dd>
+           <p>
+            Reads a yaml stream (i.e., yaml documents separated by
+            <code class="docutils literal notranslate">
+             <span class="pre">
+              &quot;\n---\n&quot;
+             </span>
+            </code>
+            ) from the
+file at
+            <cite>
+             path
+            </cite>
+            and deserializes its contents into a starlark object
+           </p>
+           <p>
+            If the
+            <cite>
+             path
+            </cite>
+            does not exist and
+            <cite>
+             default
+            </cite>
+            is not
+            <cite>
+             None
+            </cite>
+            ,
+            <cite>
+             default
+            </cite>
+            will be returned.
+In any other case, an error reading
+            <cite>
+             path
+            </cite>
+            will be a Tiltfile load error.
+           </p>
+           <table class="docutils field-list" frame="void" rules="none">
+            <col class="field-name">
+            <col class="field-body">
+            <tbody valign="top">
+             <tr class="field-odd field">
+              <th class="field-name">
+               Parameters:
+              </th>
+              <td class="field-body">
+               <ul class="first simple">
+                <li>
+                 <strong>
+                  path
+                 </strong>
+                 (
+                 <code class="xref py py-class docutils literal notranslate">
+                  <span class="pre">
+                   str
+                  </span>
+                 </code>
+                 ) &#x2013; Path to the file locally (absolute, or relative to the location of the Tiltfile).
+                </li>
+                <li>
+                 <strong>
+                  default
+                 </strong>
+                 (
+                 <code class="xref py py-data docutils literal notranslate">
+                  <span class="pre">
+                   Optional
+                  </span>
+                 </code>
+                 [
+                 <code class="xref py py-class docutils literal notranslate">
+                  <span class="pre">
+                   List
+                  </span>
+                 </code>
+                 [
+                 <code class="xref py py-data docutils literal notranslate">
+                  <span class="pre">
+                   Union
+                  </span>
+                 </code>
+                 [
+                 <code class="xref py py-class docutils literal notranslate">
+                  <span class="pre">
+                   Dict
+                  </span>
+                 </code>
+                 [
+                 <code class="xref py py-class docutils literal notranslate">
+                  <span class="pre">
+                   str
+                  </span>
+                 </code>
+                 ,
+                 <code class="xref py py-data docutils literal notranslate">
+                  <span class="pre">
+                   Any
+                  </span>
+                 </code>
+                 ],
+                 <code class="xref py py-class docutils literal notranslate">
+                  <span class="pre">
+                   List
+                  </span>
+                 </code>
+                 [
+                 <code class="xref py py-data docutils literal notranslate">
+                  <span class="pre">
+                   Any
+                  </span>
+                 </code>
+                 ]]]]) &#x2013; If not
+                 <cite>
+                  None
+                 </cite>
+                 and the file at
+                 <cite>
+                  path
+                 </cite>
+                 does not exist, this value will be returned.
+                </li>
+               </ul>
+              </td>
+             </tr>
+             <tr class="field-even field">
+              <th class="field-name">
+               Return type:
+              </th>
+              <td class="field-body">
+               <p class="first last">
+                <code class="xref py py-class docutils literal notranslate">
+                 <span class="pre">
+                  List
+                 </span>
+                </code>
+                [
+                <code class="xref py py-data docutils literal notranslate">
+                 <span class="pre">
+                  Union
+                 </span>
+                </code>
+                [
+                <code class="xref py py-class docutils literal notranslate">
+                 <span class="pre">
+                  Dict
+                 </span>
+                </code>
+                [
+                <code class="xref py py-class docutils literal notranslate">
+                 <span class="pre">
+                  str
+                 </span>
+                </code>
+                ,
+                <code class="xref py py-data docutils literal notranslate">
+                 <span class="pre">
+                  Any
+                 </span>
+                </code>
+                ],
+                <code class="xref py py-class docutils literal notranslate">
+                 <span class="pre">
+                  List
+                 </span>
+                </code>
+                [
+                <code class="xref py py-data docutils literal notranslate">
+                 <span class="pre">
+                  Any
+                 </span>
+                </code>
+                ]]]
                </p>
               </td>
              </tr>


### PR DESCRIPTION
also:
1. `decode_yaml` was in the docs twice
2. the type of `read_yaml`'s `default` was wrong