### PR TITLE
docs: fix references to container images in the illustration. Fixes https://github.com/windmilleng/tilt/issues/3037

### DIFF
--- a/docs/live_update_reference.md
+++ b/docs/live_update_reference.md
@@ -65,7 +65,7 @@ Above is an example of a valid `sync`s. A change to any of the green files will 
 </figure>
 
 
-If you have multiple Docker images that depend on each other, you can sync files from anywhere within the contexts of any of the images. (In the diagram above, Tilt is building two images; the red image depends on--i.e. `FROM`'s--the yellow image.)
+If you have multiple Docker images that depend on each other, you can sync files from anywhere within the contexts of any of the images. (In the diagram above, Tilt is building two images; the yellow image in the `server1` directory depends on--i.e. `FROM`'s--the red image in the `common` directory.)
 
 The rule of thumb is: if Tilt it watching it, you can `sync` it. (Tilt will watch it if it's in a `docker_build.context` or `custom_build.deps`).
 


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/issue3037:

0e6a73ee4f3991a7cb898f85e3087c04395066f2 (2020-03-02 10:40:45 -0500)
docs: fix references to container images in the illustration. Fixes https://github.com/windmilleng/tilt/issues/3037

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics