### PR TITLE
css/example guides: isolate css changes to tables so they don't affect api docs

### DIFF
--- a/docs/example_python.md
+++ b/docs/example_python.md
@@ -149,20 +149,10 @@ Let's click it and see what happens!
   <figcaption>Clicking the button triggers the "deploy" local_resource, which in turn kicks off an update to the server. (Click the screenshot to see an interactive view.)</figcaption>
 </figure>
 
-<table class="benchmark-report">
-  <thead>
-    <tr>
-      <th>Approach</th>
-      <th>Deploy Time (after initial)</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>Naive</td>
-      <td>10-11s</td>
-    </tr>
-  </tbody>
-</table>
+| Approach | Deploy Time (after initial)
+|---|---|
+| Naive | 10-11s |
+{:.benchmark-report}
 
 Can we do better?
 
@@ -212,24 +202,11 @@ Tilt was able to update the container in less than two seconds! (And a chunk of 
 
 ### Final Score
 
-<table class="benchmark-report">
-  <thead>
-    <tr>
-      <th>Approach</th>
-      <th>Deploy Time (after initial)</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>Naive</td>
-      <td>10-11s</td>
-    </tr>
-    <tr>
-      <td>With live_update</td>
-      <td>1-2s</td>
-    </tr>
-  </tbody>
-</table>
+| Approach | Deploy Time (after initial)
+|---|---|
+| Naive | 10-11s |
+| With live_update | 1-2s |
+{:.benchmark-report}
 
 You can try the server here:
 

--- a/docs/example_python.md
+++ b/docs/example_python.md
@@ -149,9 +149,20 @@ Let's click it and see what happens!
   <figcaption>Clicking the button triggers the "deploy" local_resource, which in turn kicks off an update to the server. (Click the screenshot to see an interactive view.)</figcaption>
 </figure>
 
-| Approach | Deploy Time (after initial)
-|---|---|
-| Naive | 10-11s |
+<table class="benchmark-report">
+  <thead>
+    <tr>
+      <th>Approach</th>
+      <th>Deploy Time (after initial)</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Naive</td>
+      <td>10-11s</td>
+    </tr>
+  </tbody>
+</table>
 
 Can we do better?
 
@@ -201,10 +212,24 @@ Tilt was able to update the container in less than two seconds! (And a chunk of 
 
 ### Final Score
 
-| Approach | Deploy Time (after initial)
-|---|---|
-| Naive | 10-11s |
-| With live_update | 1-2s |
+<table class="benchmark-report">
+  <thead>
+    <tr>
+      <th>Approach</th>
+      <th>Deploy Time (after initial)</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Naive</td>
+      <td>10-11s</td>
+    </tr>
+    <tr>
+      <td>With live_update</td>
+      <td>1-2s</td>
+    </tr>
+  </tbody>
+</table>
 
 You can try the server here:
 

--- a/docs/example_static_html.md
+++ b/docs/example_static_html.md
@@ -121,20 +121,10 @@ Let's click the button on the `deploy` resource and see what happens!
   <figcaption>Step 1 complete. Click the screenshot to see an interactive snapshot.</figcaption>
 </figure>
 
-<table class="benchmark-report">
-  <thead>
-    <tr>
-      <th>Approach</th>
-      <th>Deploy Time</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>Naive</td>
-      <td>1-2s</td>
-    </tr>
-  </tbody>
-</table>
+| Approach | Deploy Time |
+|---|---|
+| Naive | 1-2s |
+{:.benchmark-report}
 
 Can we do better?
 
@@ -180,24 +170,11 @@ Tilt was able to update the container in less than a second!
 
 ### Final Score
 
-<table class="benchmark-report">
-  <thead>
-    <tr>
-      <th>Approach</th>
-      <th>Deploy Time</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>Naive</td>
-      <td>1-2s</td>
-    </tr>
-    <tr>
-      <td>With live_update</td>
-      <td>0-1s</td>
-    </tr>
-  </tbody>
-</table>
+| Approach | Deploy Time |
+|---|---|
+| Naive | 1-2s |
+| With live_update | 0-1s |
+{:.benchmark-report}
 
 You can try the server here:
 

--- a/docs/example_static_html.md
+++ b/docs/example_static_html.md
@@ -121,9 +121,20 @@ Let's click the button on the `deploy` resource and see what happens!
   <figcaption>Step 1 complete. Click the screenshot to see an interactive snapshot.</figcaption>
 </figure>
 
-| Approach | Deploy Time |
-|---|---|
-| Naive | 1-2s |
+<table class="benchmark-report">
+  <thead>
+    <tr>
+      <th>Approach</th>
+      <th>Deploy Time</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Naive</td>
+      <td>1-2s</td>
+    </tr>
+  </tbody>
+</table>
 
 Can we do better?
 
@@ -169,10 +180,24 @@ Tilt was able to update the container in less than a second!
 
 ### Final Score
 
-| Approach | Deploy Time |
-|---|---|
-| Naive | 1-2s |
-| With live_update | 0-1s |
+<table class="benchmark-report">
+  <thead>
+    <tr>
+      <th>Approach</th>
+      <th>Deploy Time</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Naive</td>
+      <td>1-2s</td>
+    </tr>
+    <tr>
+      <td>With live_update</td>
+      <td>0-1s</td>
+    </tr>
+  </tbody>
+</table>
 
 You can try the server here:
 

--- a/src/_sass/layout.scss
+++ b/src/_sass/layout.scss
@@ -1393,15 +1393,16 @@ input[type=checkbox]:checked + .formItem-checkbox {
   background-color: rgba($color-red, 0.3);
 }
 
-table {
+table.benchmark-report {
   margin: $spacing-unit;
   border-spacing: 0;
-}
-thead th {
-  border-bottom: 1px solid black;
-}
-th, td {
-  padding: $spacing-unit / 4;
-  text-align: center;
-  min-width: $spacing-unit * 4;
+  thead th {
+    border-bottom: 1px solid black;
+  }
+
+  th, td {
+    padding: $spacing-unit / 4;
+    text-align: center;
+    min-width: $spacing-unit * 4;
+  }
 }


### PR DESCRIPTION
Hello @nicks, @landism,

Please review the following commits I made in branch maiamcc/fix-centered-table:

f3217ece541badf1c3a76f3443c697e5d6e3ac15 (2020-03-11 18:12:24 -0400)
css/example guides: isolate css changes to tables so they don't affect api docs

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics