### PR TITLE
link to starlack spec at top of API reference

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -2,6 +2,8 @@
 title: Tiltfile API Reference
 layout: docs
 ---
+Tiltfiles are written in _Starlark_, a dialect of Python. For more information on Starlark's built-ins, [see the **Starlark Spec**](https://github.com/bazelbuild/starlark/blob/master/spec.md). The rest of this page details Tiltfile-specific functionality.
+
 
 ## Data
 


### PR DESCRIPTION
lots of really with-it users (e.g. [Tom Elliott](https://kubernetes.slack.com/archives/CESBL84MV/p1583872879153900?thread_ts=1583868658.149400&cid=CESBL84MV)
didn't know this was a thing