### PR TITLE
docs: fix example go formatting

### DIFF
--- a/docs/example_go.md
+++ b/docs/example_go.md
@@ -158,8 +158,10 @@ Our benchmarks show this is slow. Can we do better?
 What's taking up so much time? The logs show that when we make the change to a file, we:
 
 1) Copy the source files to the image.
+
 2) Download the `gorilla/mux` dependency.
-3) Re-compile the Go binary from scratch.
+
+3) Compile the Go binary from scratch.
 
 But the Go team has done a lot of work to make caching dependencies and
 incremental compiles fast.  How can we better use the Go tools how they're meant


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/goformatting:

74f50c16cebb6781b8b87594c800039738f9168a (2020-03-17 19:55:48 -0400)
docs: fix example go formatting

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics