### PR TITLE
docs: clarify docs for ignore and only params

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -93,7 +93,7 @@ def docker_build(ref: str, context: str, build_args: Dict[str, str] = {}, docker
 
     docker build /path/to/code -t myregistry/myproj/backend
 
-  For more information on the `ignore` and `only` parameters, see our `Guide to File Changes <http://localhost:4001/file_changes.html>`_.
+  For more information on the `ignore` and `only` parameters, see our `Guide to File Changes </file_changes.html>`_.
 
   Note that you can't set both the `dockerfile` and `dockerfile_contents` arguments (will throw an error).
 

--- a/api/api.py
+++ b/api/api.py
@@ -36,7 +36,7 @@ def set_team(team_id: str) -> None:
 
   Sends usage information to Tilt Cloud periodically.
   """
-  pass  
+  pass
 
 def sync(local_path: str, remote_path: str) -> LiveUpdateStep:
   """Specify that any changes to `localPath` should be synced to `remotePath`
@@ -81,13 +81,23 @@ def restart_container() -> LiveUpdateStep:
 def docker_build(ref: str, context: str, build_args: Dict[str, str] = {}, dockerfile: str = "Dockerfile", dockerfile_contents: Union[str, Blob] = "", live_update: List[LiveUpdateStep]=[], match_in_env_vars: bool = False, ignore: Union[str, List[str]] = [], only: Union[str, List[str]] = [], entrypoint: str = "", target: str = "", ssh: Union[str, List[str]] = "", network: str = "", secret: Union[str, List[str]] = "", extra_tag: Union[str, List[str]] = "", container_args: List[str] = None) -> None:
   """Builds a docker image.
 
+  The invocation
+
+  .. code-block:: python
+
+    docker_build('myregistry/myproj/backend', '/path/to/code')
+
+  is roughly equivalent to the shell call
+
+  .. code-block:: bash
+
+    docker build /path/to/code -t myregistry/myproj/backend
+
+  For more information on the `ignore` and `only` parameters, see our `Guide to File Changes <http://localhost:4001/file_changes.html>`_.
+
   Note that you can't set both the `dockerfile` and `dockerfile_contents` arguments (will throw an error).
 
-  Example: ``docker_build('myregistry/myproj/backend', '/path/to/code')`` is roughly equivalent to the call ``docker build /path/to/code -t myregistry/myproj/backend``
-
-  Note: If you're using the the `ignore` and `only` parameters to do context filtering and you have tricky cases, reach out to us. The implementation is complex and there might be edge cases.
-
-  Note: the `entrypoint` parameter is not supported for Docker Compose resources. If you need it for your use case, let us know.
+  Note also that the `entrypoint` parameter is not supported for Docker Compose resources. If you need it for your use case, let us know.
 
   Args:
     ref: name for this image (e.g. 'myproj/backend' or 'myregistry/myproj/backend'). If this image will be used in a k8s resource(s), this ref must match the ``spec.container.image`` param for that resource(s).
@@ -97,8 +107,8 @@ def docker_build(ref: str, context: str, build_args: Dict[str, str] = {}, docker
     dockerfile_contents: raw contents of the Dockerfile to use for this build.
     live_update: set of steps for updating a running container (see `Live Update documentation <live_update_reference.html>`_).
     match_in_env_vars: specifies that k8s objects can reference this image in their environment variables, and Tilt will handle those variables the same as it usually handles a k8s container spec's ``image`` s.
-    ignore: set of file patterns that will be ignored. Ignored files will not trigger builds and will not be included in images. Follows the `dockerignore syntax <https://docs.docker.com/engine/reference/builder/#dockerignore-file>`_.
-    only: set of file paths that should be considered for the build. All other changes will not trigger a build and will not be included in images. Inverse of ignore parameter. Only accepts real paths, not file globs.
+    ignore: set of file patterns that will be ignored. Ignored files will not trigger builds and will not be included in images. Follows the `dockerignore syntax <https://docs.docker.com/engine/reference/builder/#dockerignore-file>`_. Patterns will be evaluated relative to ``context``.
+    only: set of file paths that should be considered for the build. All other changes will not trigger a build and will not be included in images. Inverse of ignore parameter. Only accepts real paths, not file globs. Patterns will be evaluated relative to ``context``.
     entrypoint: command to run when this container starts. Takes precedence over the container's ``CMD`` or ``ENTRYPOINT``, and over a `container command specified in k8s YAML <https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/>`_. Will be evaluated in a shell context: e.g. ``entrypoint="foo.sh bar"`` will be executed in the container as ``/bin/sh -c 'foo.sh bar'``.
     target: Specify a build stage in the Dockerfile. Equivalent to the ``docker build --target`` flag.
     ssh: Include SSH secrets in your build. Use ssh='default' to clone private repositories inside a Dockerfile. Uses the syntax in the `docker build --ssh flag <https://docs.docker.com/develop/develop-images/build_enhancements/#using-ssh-to-access-private-data-in-builds>`_.
@@ -581,7 +591,7 @@ def custom_build(ref: str, command: str, deps: List[str], tag: str = "", disable
     skips_local_docker: Whether your build command writes the image to your local Docker image store. Set this to true if you're using a cloud-based builder or independent image builder like ``buildah``.
     live_update: set of steps for updating a running container (see `Live Update documentation <live_update_reference.html>`_).
     match_in_env_vars: specifies that k8s objects can reference this image in their environment variables, and Tilt will handle those variables the same as it usually handles a k8s container spec's ``image`` s.
-    ignore: set of file patterns that will be ignored. Ignored files will not trigger builds and will not be included in images. Follows the `dockerignore syntax <https://docs.docker.com/engine/reference/builder/#dockerignore-file>`_.
+    ignore: set of file patterns that will be ignored. Ignored files will not trigger builds and will not be included in images. Follows the `dockerignore syntax <https://docs.docker.com/engine/reference/builder/#dockerignore-file>`_. Patterns/filepaths will be evaluated relative to each ``dep`` (e.g. if you specify ``deps=['dep1', 'dep2']`` and ``ignores=['foobar']``, Tilt will ignore both ``deps1/foobar`` and ``dep2/foobar``).
     entrypoint: command to run when this container starts. Takes precedence over the container's ``CMD`` or ``ENTRYPOINT``, and over a `container command specified in k8s YAML <https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/>`_. Will be evaluated in a shell context: e.g. ``entrypoint="foo.sh bar"`` will be executed in the container as ``/bin/sh -c 'foo.sh bar'``.
   """
   pass

--- a/api/api.py
+++ b/api/api.py
@@ -107,8 +107,8 @@ def docker_build(ref: str, context: str, build_args: Dict[str, str] = {}, docker
     dockerfile_contents: raw contents of the Dockerfile to use for this build.
     live_update: set of steps for updating a running container (see `Live Update documentation <live_update_reference.html>`_).
     match_in_env_vars: specifies that k8s objects can reference this image in their environment variables, and Tilt will handle those variables the same as it usually handles a k8s container spec's ``image`` s.
-    ignore: set of file patterns that will be ignored. Ignored files will not trigger builds and will not be included in images. Follows the `dockerignore syntax <https://docs.docker.com/engine/reference/builder/#dockerignore-file>`_. Patterns will be evaluated relative to ``context``.
-    only: set of file paths that should be considered for the build. All other changes will not trigger a build and will not be included in images. Inverse of ignore parameter. Only accepts real paths, not file globs. Patterns will be evaluated relative to ``context``.
+    ignore: set of file patterns that will be ignored. Ignored files will not trigger builds and will not be included in images. Follows the `dockerignore syntax <https://docs.docker.com/engine/reference/builder/#dockerignore-file>`_. Patterns will be evaluated relative to the ``context`` parameter.
+    only: set of file paths that should be considered for the build. All other changes will not trigger a build and will not be included in images. Inverse of ignore parameter. Only accepts real paths, not file globs. Patterns will be evaluated relative to the ``context`` parameter.
     entrypoint: command to run when this container starts. Takes precedence over the container's ``CMD`` or ``ENTRYPOINT``, and over a `container command specified in k8s YAML <https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/>`_. Will be evaluated in a shell context: e.g. ``entrypoint="foo.sh bar"`` will be executed in the container as ``/bin/sh -c 'foo.sh bar'``.
     target: Specify a build stage in the Dockerfile. Equivalent to the ``docker build --target`` flag.
     ssh: Include SSH secrets in your build. Use ssh='default' to clone private repositories inside a Dockerfile. Uses the syntax in the `docker build --ssh flag <https://docs.docker.com/develop/develop-images/build_enhancements/#using-ssh-to-access-private-data-in-builds>`_.
@@ -715,7 +715,7 @@ def local_resource(name: str, cmd: str = "", deps: Union[str, List[str]] = None,
       `Manual Update Control docs <manual_update_control.html>`_.
     resource_deps: a list of resources on which this resource depends.
       See the `Resource Dependencies docs <resource_dependencies.html>`_.
-    ignore: set of file patterns that will be ignored. Ignored files will not trigger runs. Follows the `dockerignore syntax <https://docs.docker.com/engine/reference/builder/#dockerignore-file>`_.
+    ignore: set of file patterns that will be ignored. Ignored files will not trigger runs. Follows the `dockerignore syntax <https://docs.docker.com/engine/reference/builder/#dockerignore-file>`_. Patterns will be evaluated relative to the Tiltfile.
     auto_init: whether this resource runs on ``tilt up``. Defaults to ``True``. Note that ``auto_init=False`` is only compatible with ``trigger_mode=TRIGGER_MODE_MANUAL``.
     serve_cmd: Tilt will run this command on update and expect it to not exit
   """

--- a/docs/custom_build.md
+++ b/docs/custom_build.md
@@ -123,7 +123,7 @@ Tilt's `docker_build` supports other options. The most impactful is [Live Update
 
 `custom_build` supports most other options of `docker_build`, and a few specific to non-Docker container builders. If you find an option you think should exist but doesn't, let us know in the `#tilt` channel in [Kubernetes Slack](http://slack.k8s.io).
 
-### Adjust Filewatching wtih `ignore`
+### Adjust File Watching with `ignore`
 While most of the points in our [Debugging File Changes](/file_changes.html) guide hold true for `custom_build`, the `ignore` parameter (which adjusts the set of files watched for a given build) works a bit differently, and is worth discussing briefly.
 
 The `ignore` parameter takes a pattern or list of patterns (following [`.dockerignore` syntax](https://docs.docker.com/engine/reference/builder/#dockerignore-file); files matching any of these patterns will _not_ trigger a build.

--- a/docs/custom_build.md
+++ b/docs/custom_build.md
@@ -123,6 +123,22 @@ Tilt's `docker_build` supports other options. The most impactful is [Live Update
 
 `custom_build` supports most other options of `docker_build`, and a few specific to non-Docker container builders. If you find an option you think should exist but doesn't, let us know in the `#tilt` channel in [Kubernetes Slack](http://slack.k8s.io).
 
+### Adjust Filewatching wtih `ignore`
+While most of the points in our [Debugging File Changes](/file_changes.html) guide hold true for `custom_build`, the `ignore` parameter (which adjusts the set of files watched for a given build) works a bit differently, and is worth discussing briefly.
+
+The `ignore` parameter takes a pattern or list of patterns (following [`.dockerignore` syntax](https://docs.docker.com/engine/reference/builder/#dockerignore-file); files matching any of these patterns will _not_ trigger a build.
+
+Of note, these patterns are evaluated relative to each ``dep``. E.g. given the following call:
+```python
+custom_build(
+    'image-foo',
+    'docker build -t $EXPECTED_REF .',
+    deps==['dep1', 'dep2'],
+    ignores=['baz']
+)
+```
+Tilt will ignore `dep1/baz` and `dep2/baz`.
+
 ## Why Tilt uses One-Time Tags
 This section describes for the curious why Tilt uses tags the way it does, instead of using a fixed reference.
 Kubernetes (and the [OCI model](https://github.com/opencontainers/image-spec) generally) support multiple ways to reference an image:

--- a/docs/file_changes.md
+++ b/docs/file_changes.md
@@ -94,6 +94,18 @@ patterns.
 For this specific `docker_build()` call, files that match these patterns will
 not trigger rebuilds, and will be excluded from the Docker build context.
 
+The patterns are evaluated relative to the `context` argument passed to `docker_build`. For instance, given the call:
+```python
+docker_build(
+    'image-foo',
+    './foo',  # context
+    only=['bar']
+)
+```
+Tilt will ignore the file `foo/bar`.
+
+(Note that `custom_build` handles the `ignore` parameter a little differently than `docker_build` does; for more info, see our [Custom Build Guide](custom_build.html#adjust-filewatching-wtih-ignore)).
+
 ### docker_build and only=
 
 The `docker_build()` call's `only=` parameter excludes everything *but* the file
@@ -101,8 +113,11 @@ paths specified in `only`.
 
 For example,
 
-```
-docker_build('image-name', '.', only=['./src', './static-files'])
+```python
+docker_build(
+    'image-foo',
+    './foo',
+    only=['./src', './static-files'])
 ```
 
 is equivalent to having a `.dockerignore` file that looks like:
@@ -114,6 +129,8 @@ is equivalent to having a `.dockerignore` file that looks like:
 ```
 
 The `only=` parameter accepts paths, not glob patterns.
+
+Again, these paths are evaluated relative to the `context` passed to `docker_build`; in the call above, the only directories included in the resulting image are `foo/src` and `foo/static-files`.
 
 ### .tiltignore
 

--- a/docs/file_changes.md
+++ b/docs/file_changes.md
@@ -104,7 +104,7 @@ docker_build(
 ```
 Tilt will ignore the file `foo/bar`.
 
-(Note that `custom_build` handles the `ignore` parameter a little differently than `docker_build` does; for more info, see our [Custom Build Guide](custom_build.html#adjust-filewatching-wtih-ignore)).
+(Note that `custom_build` handles the `ignore` parameter a little differently than `docker_build` does; for more info, see our [Custom Build Guide](custom_build.html#adjust-file-watching-wtih-ignore)).
 
 ### docker_build and only=
 

--- a/src/_includes/api/functions.html
+++ b/src/_includes/api/functions.html
@@ -1456,7 +1456,7 @@ ensures a pretty high bar of intent.
              only
             </cite>
             parameters, see our
-            <a class="reference external" href="http://localhost:4001/file_changes.html">
+            <a class="reference external" href="/file_changes.html">
              Guide to File Changes
             </a>
             .
@@ -1670,13 +1670,13 @@ ensures a pretty high bar of intent.
                   <a class="reference external" href="https://docs.docker.com/engine/reference/builder/#dockerignore-file">
                    dockerignore syntax
                   </a>
-                  . Patterns will be evaluated relative to
+                  . Patterns will be evaluated relative to the
                   <code class="docutils literal notranslate">
                    <span class="pre">
                     context
                    </span>
                   </code>
-                  .
+                  parameter.
                  </p>
                 </li>
                 <li>
@@ -1707,13 +1707,13 @@ ensures a pretty high bar of intent.
                    str
                   </span>
                  </code>
-                 ]]) &#x2013; set of file paths that should be considered for the build. All other changes will not trigger a build and will not be included in images. Inverse of ignore parameter. Only accepts real paths, not file globs. Patterns will be evaluated relative to
+                 ]]) &#x2013; set of file paths that should be considered for the build. All other changes will not trigger a build and will not be included in images. Inverse of ignore parameter. Only accepts real paths, not file globs. Patterns will be evaluated relative to the
                  <code class="docutils literal notranslate">
                   <span class="pre">
                    context
                   </span>
                  </code>
-                 .
+                 parameter.
                 </li>
                 <li>
                  <strong>
@@ -4619,7 +4619,7 @@ See the
                   <a class="reference external" href="https://docs.docker.com/engine/reference/builder/#dockerignore-file">
                    dockerignore syntax
                   </a>
-                  .
+                  . Patterns will be evaluated relative to the Tiltfile.
                  </p>
                 </li>
                 <li>

--- a/src/_includes/api/functions.html
+++ b/src/_includes/api/functions.html
@@ -571,7 +571,40 @@ then re-tag it with its own tag before pushing to your cluster. See
                  <a class="reference external" href="https://docs.docker.com/engine/reference/builder/#dockerignore-file">
                   dockerignore syntax
                  </a>
-                 .
+                 . Patterns/filepaths will be evaluated relative to each
+                 <code class="docutils literal notranslate">
+                  <span class="pre">
+                   dep
+                  </span>
+                 </code>
+                 (e.g. if you specify
+                 <code class="docutils literal notranslate">
+                  <span class="pre">
+                   deps=[&apos;dep1&apos;,
+                  </span>
+                  <span class="pre">
+                   &apos;dep2&apos;]
+                  </span>
+                 </code>
+                 and
+                 <code class="docutils literal notranslate">
+                  <span class="pre">
+                   ignores=[&apos;foobar&apos;]
+                  </span>
+                 </code>
+                 , Tilt will ignore both
+                 <code class="docutils literal notranslate">
+                  <span class="pre">
+                   deps1/foobar
+                  </span>
+                 </code>
+                 and
+                 <code class="docutils literal notranslate">
+                  <span class="pre">
+                   dep2/foobar
+                  </span>
+                 </code>
+                 ).
                 </li>
                 <li>
                  <strong>
@@ -1396,6 +1429,39 @@ ensures a pretty high bar of intent.
             Builds a docker image.
            </p>
            <p>
+            The invocation
+           </p>
+           <div class="highlight-python notranslate">
+            <div class="highlight">
+             <pre><span></span><span class="n">docker_build</span><span class="p">(</span><span class="s1">&apos;myregistry/myproj/backend&apos;</span><span class="p">,</span> <span class="s1">&apos;/path/to/code&apos;</span><span class="p">)</span>
+</pre>
+            </div>
+           </div>
+           <p>
+            is roughly equivalent to the shell call
+           </p>
+           <div class="highlight-bash notranslate">
+            <div class="highlight">
+             <pre><span></span>docker build /path/to/code -t myregistry/myproj/backend
+</pre>
+            </div>
+           </div>
+           <p>
+            For more information on the
+            <cite>
+             ignore
+            </cite>
+            and
+            <cite>
+             only
+            </cite>
+            parameters, see our
+            <a class="reference external" href="http://localhost:4001/file_changes.html">
+             Guide to File Changes
+            </a>
+            .
+           </p>
+           <p>
             Note that you can&#x2019;t set both the
             <cite>
              dockerfile
@@ -1407,47 +1473,7 @@ ensures a pretty high bar of intent.
             arguments (will throw an error).
            </p>
            <p>
-            Example:
-            <code class="docutils literal notranslate">
-             <span class="pre">
-              docker_build(&apos;myregistry/myproj/backend&apos;,
-             </span>
-             <span class="pre">
-              &apos;/path/to/code&apos;)
-             </span>
-            </code>
-            is roughly equivalent to the call
-            <code class="docutils literal notranslate">
-             <span class="pre">
-              docker
-             </span>
-             <span class="pre">
-              build
-             </span>
-             <span class="pre">
-              /path/to/code
-             </span>
-             <span class="pre">
-              -t
-             </span>
-             <span class="pre">
-              myregistry/myproj/backend
-             </span>
-            </code>
-           </p>
-           <p>
-            Note: If you&#x2019;re using the the
-            <cite>
-             ignore
-            </cite>
-            and
-            <cite>
-             only
-            </cite>
-            parameters to do context filtering and you have tricky cases, reach out to us. The implementation is complex and there might be edge cases.
-           </p>
-           <p>
-            Note: the
+            Note also that the
             <cite>
              entrypoint
             </cite>
@@ -1644,6 +1670,12 @@ ensures a pretty high bar of intent.
                   <a class="reference external" href="https://docs.docker.com/engine/reference/builder/#dockerignore-file">
                    dockerignore syntax
                   </a>
+                  . Patterns will be evaluated relative to
+                  <code class="docutils literal notranslate">
+                   <span class="pre">
+                    context
+                   </span>
+                  </code>
                   .
                  </p>
                 </li>
@@ -1675,7 +1707,13 @@ ensures a pretty high bar of intent.
                    str
                   </span>
                  </code>
-                 ]]) &#x2013; set of file paths that should be considered for the build. All other changes will not trigger a build and will not be included in images. Inverse of ignore parameter. Only accepts real paths, not file globs.
+                 ]]) &#x2013; set of file paths that should be considered for the build. All other changes will not trigger a build and will not be included in images. Inverse of ignore parameter. Only accepts real paths, not file globs. Patterns will be evaluated relative to
+                 <code class="docutils literal notranslate">
+                  <span class="pre">
+                   context
+                  </span>
+                 </code>
+                 .
                 </li>
                 <li>
                  <strong>


### PR DESCRIPTION
a user in #tilt expressed confusion with the docs on `ignore` and `only`
(e.g. they didn't know what directory they're evaluated relative to).
This PR attempts to clarify the API docs and the File Changes Guide
on this point.