### PR TITLE
all frontmatter urls should omit the trailing '/', per recommendation here:

### DIFF
--- a/blog/_config-dev.yml
+++ b/blog/_config-dev.yml
@@ -1,5 +1,5 @@
 url: "http://localhost:4002"
-docsurl: "http://localhost:4001/"
-landingurl: "http://localhost:4000/"
-blogurl: "http://localhost:4002/"
+docsurl: "http://localhost:4001"
+landingurl: "http://localhost:4000"
+blogurl: "http://localhost:4002"
 host: 0.0.0.0

--- a/blog/_config.yml
+++ b/blog/_config.yml
@@ -4,9 +4,9 @@ description: >-
   Thoughts on how to make microservices easier to run, debug, and collaborate on locally
 baseurl: ""
 url: "https://blog.tilt.dev"
-docsurl: "https://docs.tilt.dev/"
-landingurl: "https://tilt.dev/"
-blogurl: "https://blog.tilt.dev/"
+docsurl: "https://docs.tilt.dev"
+landingurl: "https://tilt.dev"
+blogurl: "https://blog.tilt.dev"
 twitter_username: tilt_dev
 github_username:  windmilleng
 google_analytics: UA-129150759-3

--- a/docs/_config-dev.yml
+++ b/docs/_config-dev.yml
@@ -1,4 +1,4 @@
-docsurl: "http://localhost:4001/"
-landingurl: "http://localhost:4000/"
-blogurl: "http://localhost:4002/"
+docsurl: "http://localhost:4001"
+landingurl: "http://localhost:4000"
+blogurl: "http://localhost:4002"
 host: 0.0.0.0

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -3,10 +3,10 @@ email: hi@tilt.dev
 description: >-
   Local Kubernetes development with no stress
 baseurl: ""
-url: "https://docs.tilt.dev/"
-docsurl: "https://docs.tilt.dev/"
-landingurl: "https://tilt.dev/"
-blogurl: "https://blog.tilt.dev/"
+url: "https://docs.tilt.dev"
+docsurl: "https://docs.tilt.dev"
+landingurl: "https://tilt.dev"
+blogurl: "https://blog.tilt.dev"
 twitter_username: tilt_dev
 github_username:  windmilleng
 google_analytics: UA-129150759-2

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@ layout: docs
 
 Local Kubernetes development with no stress.
 
-[Tilt]({{site.landingurl}}) helps you develop your microservices locally,
+[Tilt]({{site.landingurl}}/) helps you develop your microservices locally,
 especially if [you deploy to Kubernetes or are planning to](https://blog.tilt.dev/2020/02/12/local-dev.html).
 Run `tilt up` to start working on your services in a complete dev environment
 configured for your team.

--- a/src/_config-dev.yml
+++ b/src/_config-dev.yml
@@ -1,4 +1,4 @@
-docsurl: "http://localhost:4001/"
-landingurl: "http://localhost:4000/"
-blogurl: "http://localhost:4002/"
+docsurl: "http://localhost:4001"
+landingurl: "http://localhost:4000"
+blogurl: "http://localhost:4002"
 host: 0.0.0.0

--- a/src/_config.yml
+++ b/src/_config.yml
@@ -3,10 +3,10 @@ email: hi@tilt.dev
 description: >-
   Local Kubernetes development with no stress
 baseurl: ""
-url: "https://tilt.dev/"
-docsurl: "https://docs.tilt.dev/"
-landingurl: "https://tilt.dev/"
-blogurl: "https://blog.tilt.dev/"
+url: "https://tilt.dev"
+docsurl: "https://docs.tilt.dev"
+landingurl: "https://tilt.dev"
+blogurl: "https://blog.tilt.dev"
 twitter_username: tilt_dev
 github_username:  windmilleng
 google_analytics: UA-129150759-1

--- a/src/_includes/cta_docs.html
+++ b/src/_includes/cta_docs.html
@@ -8,7 +8,7 @@
     <div class="u-clearBoth">
       You’ll be able to setup Tilt
       in no time and start getting things done.
-      <a class="bleedingLink" href="{{site.docsurl}}">&thinsp;<span class="bleedingLink-text">Check out the docs</span>!&hairsp;</a>
+      <a class="bleedingLink" href="{{site.docsurl}}/">&thinsp;<span class="bleedingLink-text">Check out the docs</span>!&hairsp;</a>
     </div>
   </div>
 
@@ -19,7 +19,7 @@
     </h4>
 
     <div class="u-clearBoth">
-      We’d&thinsp;<a class="bleedingLink" href="{{site.landingurl}}contact">&thinsp;<span class="bleedingLink-text">love to chat</span>.&hairsp;</a>
+      We’d&thinsp;<a class="bleedingLink" href="{{site.landingurl}}/contact">&thinsp;<span class="bleedingLink-text">love to chat</span>.&hairsp;</a>
     </div>
   </div>
 </div>

--- a/src/_includes/footer.html
+++ b/src/_includes/footer.html
@@ -7,11 +7,11 @@
       {% for link in site.data.footer %}
       {% assign href = link.href %}
       {% if link.landingurl %}
-      {% assign href = (href | prepend: site.landingurl) %}
+      {% assign href = (href | prepend: "/" | prepend: site.landingurl) %}
       {% elsif link.docsurl %}
-      {% assign href = (href | prepend: site.docsurl) %}
+      {% assign href = (href | prepend: "/" | prepend: site.docsurl) %}
       {% elsif link.blogurl %}
-      {% assign href = (href | prepend: site.blogurl) %}
+      {% assign href = (href | prepend: "/" | prepend: site.blogurl) %}
       {% endif %}
       <a class="circleLinkIcon" href="{{href}}">
         {% svg assets/svg/{{link.icon}}.svg alt="{{link.name}}" %}

--- a/src/_includes/header.html
+++ b/src/_includes/header.html
@@ -4,11 +4,11 @@
 
   <div class="wrapper wrapper--header">
     {% if page.layout == 'landing' %}
-    <a class="imageLink imageLink--logo-imagemark" href="{{site.landingurl}}">
+    <a class="imageLink imageLink--logo-imagemark" href="{{site.landingurl}}/">
       {% svg assets/svg/logo-imagemark.svg %}
     </a>
     {% else %}
-    <a class="imageLink imageLink--logo-wordmark-anim" href="{{site.landingurl}}">
+    <a class="imageLink imageLink--logo-wordmark-anim" href="{{site.landingurl}}/">
       {% svg assets/svg/logo-wordmark-anim.svg %}
     </a>
     {% endif %}
@@ -25,11 +25,11 @@
         {% for link in site.data.header %}
         {% assign href = link.href %}
         {% if link.landingurl %}
-        {% assign href = (href | prepend: site.landingurl) %}
+        {% assign href = (href | prepend: "/" | prepend: site.landingurl) %}
         {% elsif link.docsurl %}
-        {% assign href = (href | prepend: site.docsurl) %}
+        {% assign href = (href | prepend: "/" | prepend: site.docsurl) %}
         {% elsif link.blogurl %}
-        {% assign href = (href | prepend: site.blogurl) %}
+        {% assign href = (href | prepend: "/" | prepend: site.blogurl) %}
         {% endif %}
         <a class="headerLink headerLink--{{link.icon}} u-hideOnMobile" href="{{href}}">
           {% svg assets/svg/{{link.icon}}.svg %}
@@ -52,11 +52,11 @@
           {% for link in site.data.header %}
           {% assign href = link.href %}
           {% if link.landingurl %}
-          {% assign href = (href | prepend: site.landingurl) %}
+          {% assign href = (href | prepend: "/" | prepend: site.landingurl) %}
           {% elsif link.docsurl %}
-          {% assign href = (href | prepend: site.docsurl) %}
+          {% assign href = (href | prepend: "/" | prepend: site.docsurl) %}
           {% elsif link.blogurl %}
-          {% assign href = (href | prepend: site.blogurl) %}
+          {% assign href = (href | prepend: "/" | prepend: site.blogurl) %}
           {% endif %}
           <a class="headerLink headerLink--{{link.mobileIcon}} headerLink--mobile" href="{{href}}">
           {% svg assets/svg/{{link.mobileIcon}}.svg %}

--- a/src/_includes/preview.html
+++ b/src/_includes/preview.html
@@ -44,7 +44,7 @@
     <div class="postPreview-credit">
       {% assign author = site.data.people[post.author] %}
       <img class="postPreview-creditImg" src="/assets/img/{{ post.author }}.jpg">
-      <div><a href="{{ site.landingurl }}about">{{ author.name }}</a></div>
+      <div><a href="{{ site.landingurl }}/about">{{ author.name }}</a></div>
     </div>
   </div>
 </div>

--- a/src/_layouts/blog.html
+++ b/src/_layouts/blog.html
@@ -23,7 +23,7 @@ layout: default
       <div class="u-marginBottom0_75">
         <img class="blogCredit-img" src="/assets/img/{{ page.author }}.jpg">
         <div>Published on <span class="blogCredit-date">{{ page.date | date_to_long_string }}</span></div>
-        <div><a href="{{ site.landingurl }}about">{{ author.name }}</a></div>
+        <div><a href="{{ site.landingurl }}/about">{{ author.name }}</a></div>
       </div>
       <div>
         {% if author.twitter %}
@@ -55,7 +55,7 @@ layout: default
       <div class="blogCredit blogCredit--mobile u-showOnlyOnDocsMobile u-marginBottom1">
         <img class="blogCredit-img" src="/assets/img/{{ page.author }}.jpg">
         <div>Published on <span class="blogCredit-date">{{ page.date | date_to_long_string }}</span></div>
-        <div><a href="{{ site.landingurl }}about">{{ author.name }}</a></div>
+        <div><a href="{{ site.landingurl }}/about">{{ author.name }}</a></div>
       </div>
       
       {{ content }}

--- a/src/index.md
+++ b/src/index.md
@@ -20,7 +20,7 @@ Get started easily, get more done, and never play twenty questions with <code>ku
 </a>
 
 <h3 class="ctaLink u-marginBottomUnit">
-    &gt; <a href="https://github.com/windmilleng/tilt">Check out our GitHub</a> & <a href="{{site.docsurl}}install.html">Install Docs</a>
+    &gt; <a href="https://github.com/windmilleng/tilt">Check out our GitHub</a> & <a href="{{site.docsurl}}/install.html">Install Docs</a>
 </h3>
 
 </div>
@@ -43,7 +43,7 @@ Get started easily, get more done, and never play twenty questions with <code>ku
   </div>
 
   <div>
-    &gt;&hairsp;<a href="{{site.docsurl}}tutorial.html">&thinsp;Try it today&thinsp;</a>
+    &gt;&hairsp;<a href="{{site.docsurl}}/tutorial.html">&thinsp;Try it today&thinsp;</a>
   </div>
   </div>
 </div>
@@ -95,7 +95,7 @@ Get started easily, get more done, and never play twenty questions with <code>ku
 <div class="row u-marginBottom3 u-marginBottom1_75OnMobile">
   <div class="col-1of4">&nbsp;</div>
   <div class="col-3of4">
-    <a href="{{site.docsurl}}install.html" class="brandButton brandButton--red">
+    <a href="{{site.docsurl}}/install.html" class="brandButton brandButton--red">
       {% include brandButtonBg.html %}
       <div class="buttonLabel brandButton-text">
         Give it a Tilt

--- a/src/post-subscribe.md
+++ b/src/post-subscribe.md
@@ -5,4 +5,4 @@ title: Thanks!
 
 ## We've subscribed you to updates from the Tilt team.
 
-Check out the <a href="{{site.docsurl}}install">Tilt User Guide</a> for tutorials on how to get started with Tilt.
+Check out the <a href="{{site.docsurl}}/install">Tilt User Guide</a> for tutorials on how to get started with Tilt.


### PR DESCRIPTION
Hello @nicks,

Please review the following commits I made in branch nicks/robots:

cbd2f55ae250f7f20215af2bfbe1d3c636afcba8 (2020-04-27 17:53:13 -0400)
all frontmatter urls should omit the trailing '/', per recommendation here: https://jekyllrb.com/docs/variables/ this makes some SEO stuff work better

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics