### PR TITLE
api ref: correct parameter name for local.command [ch6846]

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -344,11 +344,11 @@ def load(path: str, *args):
     hi() # prints "Hello world!"
   """
 
-def local(cmd: str, quiet: bool = False) -> Blob:
-  """Runs cmd on the *host* machine, waits for it to finish, and returns its stdout as a ``Blob``
+def local(command: str, quiet: bool = False) -> Blob:
+  """Runs a command on the *host* machine, waits for it to finish, and returns its stdout as a ``Blob``
 
   Args:
-    cmd: Command to run.
+    command: Command to run.
     quiet: If set to True, skips printing output to log.
   """
   pass

--- a/src/_includes/api/functions.html
+++ b/src/_includes/api/functions.html
@@ -4297,7 +4297,7 @@ to share across Tiltfiles.
             (
            </span>
            <em>
-            cmd
+            command
            </em>
            ,
            <em>
@@ -4312,7 +4312,7 @@ to share across Tiltfiles.
           </dt>
           <dd>
            <p>
-            Runs cmd on the
+            Runs a command on the
             <em>
              host
             </em>
@@ -4335,7 +4335,7 @@ to share across Tiltfiles.
                <ul class="first simple">
                 <li>
                  <strong>
-                  cmd
+                  command
                  </strong>
                  (
                  <code class="xref py py-class docutils literal notranslate">


### PR DESCRIPTION
we should maybe eventually bring `local_resource.cmd` into sync with `local.command` and `custom_build.command`, but for now at least make the documentation accurate

resolves [tilt#3278](https://github.com/windmilleng/tilt/issues/3278)