### PR TITLE
removes terminal prompt from command

### DIFF
--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -31,7 +31,7 @@ Other Upgrade Methods
 ## Homebrew (macOS or Linux)
 
 ```
-$ brew update && brew upgrade tilt-dev/tap/tilt
+brew update && brew upgrade tilt-dev/tap/tilt
 ```
 
 ## Scoop


### PR DESCRIPTION
I propose to remove the terminal prompt ($) from the upgrade command to make pasting easier