### PR TITLE
Fix homebrew install command to use default formula

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -108,7 +108,7 @@ You can also use these installers directly.
 ### Homebrew (macOS or Linux)
 
 ```bash
-brew install tilt-dev/tap/tilt
+brew install tilt
 ```
 
 ### Scoop (Windows)


### PR DESCRIPTION
Tilt can be installed using [this formula](https://github.com/Homebrew/homebrew-core/blob/main/Formula/t/tilt.rb) instead of the custom tap.