### PR TITLE
deploy: allow our urls to work on both <name>.html and <name>

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -54,6 +54,8 @@ jobs:
         if: steps.paths.outputs.blog == 'true'
         run: |
           aws s3 sync build/blog s3://prod-collaboration-blog.tilt.dev/ --region us-east-1 --delete
+          # Extensionless page copies sync as octet-stream; retag them as HTML so browsers render them.
+          aws s3 cp s3://prod-collaboration-blog.tilt.dev/ s3://prod-collaboration-blog.tilt.dev/ --recursive --exclude "*.*" --content-type text/html --metadata-directive REPLACE --region us-east-1
       - name: Invalidate CloudFront cache for blog.tilt.dev
         if: steps.paths.outputs.blog == 'true'
         run: |
@@ -74,6 +76,8 @@ jobs:
         if: steps.paths.outputs.docs == 'true'
         run: |
           aws s3 sync build/docs s3://prod-collaboration-docs.tilt.dev/ --region us-east-1 --delete
+          # Extensionless page copies sync as octet-stream; retag them as HTML so browsers render them.
+          aws s3 cp s3://prod-collaboration-docs.tilt.dev/ s3://prod-collaboration-docs.tilt.dev/ --recursive --exclude "*.*" --content-type text/html --metadata-directive REPLACE --region us-east-1
       - name: Invalidate CloudFront cache for docs.tilt.dev
         if: steps.paths.outputs.docs == 'true'
         run: |
@@ -94,6 +98,8 @@ jobs:
         if: steps.paths.outputs.site == 'true'
         run: |
           aws s3 sync build/site s3://prod-collaboration-tilt.dev/ --region us-east-1 --delete
+          # Extensionless page copies sync as octet-stream; retag them as HTML so browsers render them.
+          aws s3 cp s3://prod-collaboration-tilt.dev/ s3://prod-collaboration-tilt.dev/ --recursive --exclude "*.*" --content-type text/html --metadata-directive REPLACE --region us-east-1
       - name: Invalidate CloudFront cache for www.tilt.dev
         if: steps.paths.outputs.site == 'true'
         run: |

--- a/deploy/blog.dockerfile
+++ b/deploy/blog.dockerfile
@@ -9,6 +9,9 @@ ADD healthcheck.sh .
 
 FROM sources AS static-builder
 RUN JEKYLL_ENV=production bundle exec jekyll build -d _site
+# Create extensionless copies of every page (foo.html -> foo) so URLs work both
+# with and without the ".html" suffix once synced to S3.
+RUN find _site -type f -name '*.html' ! -name 'index.html' -exec sh -c 'cp "$1" "${1%.html}"' _ {} \;
 
 FROM scratch AS static
 COPY --from=static-builder /blog/_site /

--- a/deploy/docs.dockerfile
+++ b/deploy/docs.dockerfile
@@ -15,6 +15,10 @@ RUN npm install -g pagefind
 WORKDIR /build
 COPY --from=static-builder /docs/_site /build
 RUN pagefind --site .
+# Create extensionless copies of every page (foo.html -> foo) so URLs work both
+# with and without the ".html" suffix once synced to S3. Done after pagefind so
+# the copies aren't indexed as duplicate search results.
+RUN find . -type f -name '*.html' ! -name 'index.html' -exec sh -c 'cp "$1" "${1%.html}"' _ {} \;
 
 FROM scratch AS static
 COPY --from=search-builder /build /

--- a/deploy/site.dockerfile
+++ b/deploy/site.dockerfile
@@ -8,6 +8,9 @@ ADD healthcheck.sh .
 
 FROM sources AS static-builder
 RUN JEKYLL_ENV=production bundle exec jekyll build -d _site
+# Create extensionless copies of every page (foo.html -> foo) so URLs work both
+# with and without the ".html" suffix once synced to S3.
+RUN find _site -type f -name '*.html' ! -name 'index.html' -exec sh -c 'cp "$1" "${1%.html}"' _ {} \;
 
 FROM scratch AS static
 COPY --from=static-builder /src/_site /


### PR DESCRIPTION
for history: we used to be hosted on netlify.
we changed to an s3/cloudfront solution a while back.
we could also do this as a cloudfront function, but
the way we have cloudfront setup is kind of brittle and i'd
rather not touch it right now

Signed-off-by: Nick Santos <nicholas.j.santos@gmail.com>
