### PR TITLE
fix: resolve redirect loop on /tutorial/index.html

### DIFF
--- a/docs/tutorial/index.md
+++ b/docs/tutorial/index.md
@@ -2,7 +2,7 @@
 title: First Look at Tilt
 layout: docs
 sidebar: gettingstarted
-permalink: /tutorial/index.html
+permalink: /tutorial/
 redirect_from:
  - /tutorial.html
 ---


### PR DESCRIPTION
Permalink was set to /tutorial/index.html, causing a loop between
Netlify Pretty URLs (which redirects index.html paths to the directory)
and the canonical URL enforcement (which redirected the directory back
to index.html). Changed permalink to /tutorial/ so the canonical URL
matches Netlify's served URL.

Fixes #1207.

Signed-off-by: Nick Sieger <nick@nicksieger.com>
